### PR TITLE
Add unit tests for graph generation and mutation application

### DIFF
--- a/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -57,7 +57,7 @@ public class DataServlet extends HttpServlet {
     MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
 
-    // Generate graph data structures from proto data structure 
+    // Generate graph data structures from proto data structure
     boolean success = graphFromProtoNodes(protoNodesMap, graph, graphNodesMap);
 
     // TODO: add code if success is false
@@ -81,9 +81,7 @@ public class DataServlet extends HttpServlet {
    * @return true if the mutation was successful, false otherwise
    */
   public boolean mutateGraph(
-        Mutation mut,
-        MutableGraph<GraphNode> graph,
-        Map<String, GraphNode> graphNodesMap) {
+      Mutation mut, MutableGraph<GraphNode> graph, Map<String, GraphNode> graphNodesMap) {
     // Nodes affected by the mutation
     // second node only applicable for adding an edge and removing an edge
     String startName = mut.getStartNode();
@@ -95,13 +93,13 @@ public class DataServlet extends HttpServlet {
 
     switch (mut.getType()) {
       case ADD_NODE:
-        if(graphNodesMap.containsKey(startName)) {
+        if (graphNodesMap.containsKey(startName)) {
           // adding a duplicate node
           return false;
         }
         // Create a new node with the given name and add it to the graph and the map
-        GraphNode newGraphNode = GraphNode.create(
-            startName, new ArrayList<>(), Struct.newBuilder().build());
+        GraphNode newGraphNode =
+            GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
         graph.addNode(newGraphNode);
         graphNodesMap.put(startName, newGraphNode);
         break;
@@ -128,10 +126,10 @@ public class DataServlet extends HttpServlet {
         }
         break;
       case CHANGE_TOKEN:
-        if(startNode != null) {
+        if (startNode != null) {
           /*
            * Removing and readding the node to the graph is necessary because
-           * the hash value of the node is mutated by this change so it 
+           * the hash value of the node is mutated by this change so it
            * must be reinserted
            */
           Set<GraphNode> predecessors = graph.predecessors(startNode);
@@ -139,13 +137,13 @@ public class DataServlet extends HttpServlet {
           graph.removeNode(startNode);
           boolean success = changeNodeToken(startNode, mut.getTokenChange());
           graph.addNode(startNode);
-          for(GraphNode node : predecessors) {
+          for (GraphNode node : predecessors) {
             graph.putEdge(node, startNode);
           }
-          for(GraphNode node : successors) {
+          for (GraphNode node : successors) {
             graph.putEdge(startNode, node);
           }
-          if(!success) {
+          if (!success) {
             return false;
           }
         } else {
@@ -160,7 +158,7 @@ public class DataServlet extends HttpServlet {
   }
 
   /*
-   * Takes in a map from node name to proto-parsed node object. Populates graph with node and edge 
+   * Takes in a map from node name to proto-parsed node object. Populates graph with node and edge
    * information and graphNodesMap with links from node names to graph node objects.
    * @param protNodesMap map from node name to proto Node object parsed from input
    * @param graph Guava graph to fill with node and edge information
@@ -168,9 +166,9 @@ public class DataServlet extends HttpServlet {
    * @return false if an error occurred, true otherwise
    */
   public boolean graphFromProtoNodes(
-        Map<String, Node> protoNodesMap,
-        MutableGraph<GraphNode> graph,
-        Map<String, GraphNode> graphNodesMap) {
+      Map<String, Node> protoNodesMap,
+      MutableGraph<GraphNode> graph,
+      Map<String, GraphNode> graphNodesMap) {
 
     for (String nodeName : protoNodesMap.keySet()) {
 
@@ -186,11 +184,11 @@ public class DataServlet extends HttpServlet {
       // Add dependency edges to the graph
       for (String child : thisNode.getChildrenList()) {
         GraphNode childNode = protoNodeToGraphNode(protoNodesMap.get(child));
-        if(!graphNodesMap.containsKey(child)) {
-          // If child node is not already in the graph, add it 
+        if (!graphNodesMap.containsKey(child)) {
+          // If child node is not already in the graph, add it
           graph.addNode(childNode);
           graphNodesMap.put(child, childNode);
-        } else if(graph.hasEdgeConnecting(childNode, graphNode)) {
+        } else if (graph.hasEdgeConnecting(childNode, graphNode)) {
           // the graph is not a DAG, so we error out
           return false;
         }
@@ -209,9 +207,7 @@ public class DataServlet extends HttpServlet {
   public GraphNode protoNodeToGraphNode(Node thisNode) {
     List<String> newTokenList = new ArrayList<>();
     newTokenList.addAll(thisNode.getTokenList());
-    Struct newMetadata = Struct.newBuilder()
-                               .mergeFrom(thisNode.getMetadata())
-                               .build();
+    Struct newMetadata = Struct.newBuilder().mergeFrom(thisNode.getMetadata()).build();
     return GraphNode.create(thisNode.getName(), newTokenList, newMetadata);
   }
 

--- a/src/test/java/com/google/sps/GraphGenerationTest.java
+++ b/src/test/java/com/google/sps/GraphGenerationTest.java
@@ -153,7 +153,6 @@ public final class GraphGenerationTest {
     protoNodesMap.put("B", pNodeB);
     protoNodesMap.put("C", pNodeC);
 
-
     gNodeA = servlet.protoNodeToGraphNode(pNodeA);
     gNodeB = servlet.protoNodeToGraphNode(pNodeB);
     gNodeC = servlet.protoNodeToGraphNode(pNodeC);

--- a/src/test/java/com/google/sps/GraphGenerationTest.java
+++ b/src/test/java/com/google/sps/GraphGenerationTest.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import com.google.sps.data.GraphNode;
-import com.proto.GraphProtos.Graph;
 import com.proto.GraphProtos.Node;
 import com.proto.GraphProtos.Node.Builder;
 import org.junit.Assert;
@@ -46,15 +45,12 @@ public final class GraphGenerationTest {
   Builder nodeE = Node.newBuilder().setName("E");
   Builder nodeF = Node.newBuilder().setName("F");
 
-
   GraphNode gNodeA;
   GraphNode gNodeB;
   GraphNode gNodeC;
   GraphNode gNodeD;
   GraphNode gNodeE;
   GraphNode gNodeF;
-
-
 
   @Before
   public void setUp() {
@@ -67,7 +63,7 @@ public final class GraphGenerationTest {
     gNodeF = servlet.protoNodeToGraphNode(nodeF.build());
   }
 
-  /* 
+  /*
    * Tests that a proto node with no tokens and metadata is correctly converted
    * into an empty graph node with the same name
    */
@@ -79,7 +75,7 @@ public final class GraphGenerationTest {
     Assert.assertEquals(graphNode.metadata().getFieldsCount(), 0);
   }
 
-  /* 
+  /*
    * Tests that a proto node with tokens and no metadata is correctly converted
    * into an graph node with the same name, same token list and empty metadata
    */
@@ -100,7 +96,7 @@ public final class GraphGenerationTest {
     Assert.assertEquals(graphNode.metadata().getFieldsCount(), 0);
   }
 
-  /* 
+  /*
    * Tests that a proto node with tokens and metadata is correctly converted
    * into an graph node with the same name, same token list and same metadata
    */
@@ -113,11 +109,8 @@ public final class GraphGenerationTest {
     Value rowValue = Value.newBuilder().setStringValue("10").build();
     Value colValue = Value.newBuilder().setStringValue("17").build();
 
-
-    Struct metadata = Struct.newBuilder()
-                          .putFields("row", rowValue)
-                          .putFields("column", colValue)
-                          .build();
+    Struct metadata =
+        Struct.newBuilder().putFields("row", rowValue).putFields("column", colValue).build();
     nodeA.setMetadata(metadata);
 
     GraphNode graphNode = servlet.protoNodeToGraphNode(nodeA.build());
@@ -152,7 +145,6 @@ public final class GraphGenerationTest {
 
     nodeB.addChildren("C");
 
-
     protoNodesMap.put("A", nodeA.build());
     protoNodesMap.put("B", nodeB.build());
     protoNodesMap.put("C", nodeC.build());
@@ -182,7 +174,7 @@ public final class GraphGenerationTest {
   }
 
   /*
-   * Check that a cyclic graph is detected and an error is returned. 
+   * Check that a cyclic graph is detected and an error is returned.
    */
   @Test
   public void notDAG() {
@@ -191,7 +183,6 @@ public final class GraphGenerationTest {
     nodeA.addChildren("B");
 
     nodeB.addChildren("A");
-
 
     protoNodesMap.put("A", nodeA.build());
     protoNodesMap.put("B", nodeB.build());

--- a/src/test/java/com/google/sps/GraphGenerationTest.java
+++ b/src/test/java/com/google/sps/GraphGenerationTest.java
@@ -145,9 +145,18 @@ public final class GraphGenerationTest {
 
     nodeB.addChildren("C");
 
-    protoNodesMap.put("A", nodeA.build());
-    protoNodesMap.put("B", nodeB.build());
-    protoNodesMap.put("C", nodeC.build());
+    Node pNodeA = nodeA.build();
+    Node pNodeB = nodeB.build();
+    Node pNodeC = nodeC.build();
+
+    protoNodesMap.put("A", pNodeA);
+    protoNodesMap.put("B", pNodeB);
+    protoNodesMap.put("C", pNodeC);
+
+
+    gNodeA = servlet.protoNodeToGraphNode(pNodeA);
+    gNodeB = servlet.protoNodeToGraphNode(pNodeB);
+    gNodeC = servlet.protoNodeToGraphNode(pNodeC);
 
     MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();

--- a/src/test/java/com/google/sps/MutationTest.java
+++ b/src/test/java/com/google/sps/MutationTest.java
@@ -15,21 +15,15 @@
 package com.google.sps;
 
 import com.google.common.graph.*;
-import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
 import com.google.sps.servlets.DataServlet;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
-import java.util.Iterator;
 import com.google.sps.data.GraphNode;
-import com.proto.GraphProtos.Graph;
 import com.proto.GraphProtos.Node;
 import com.proto.GraphProtos.Node.Builder;
 import com.proto.MutationProtos.Mutation;
-import com.proto.MutationProtos.MutationList;
 import com.proto.MutationProtos.TokenMutation;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,15 +45,12 @@ public final class MutationTest {
   Builder nodeE = Node.newBuilder().setName("E");
   Builder nodeF = Node.newBuilder().setName("F");
 
-
   GraphNode gNodeA;
   GraphNode gNodeB;
   GraphNode gNodeC;
   GraphNode gNodeD;
   GraphNode gNodeE;
   GraphNode gNodeF;
-
-
 
   @Before
   public void setUp() {
@@ -77,15 +68,10 @@ public final class MutationTest {
    */
   @Test
   public void addNodeBasic() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
-    
-    Mutation addA = Mutation.newBuilder()
-                        .setType(Mutation.Type.ADD_NODE)
-                        .setStartNode("A")
-                        .build();
 
-    
+    Mutation addA = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("A").build();
 
     boolean success = servlet.mutateGraph(addA, graph, graphNodesMap);
     Assert.assertTrue(success);
@@ -101,17 +87,12 @@ public final class MutationTest {
    */
   @Test
   public void noAddDuplicates() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();  
-    graph.addNode(gNodeA);    
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
+    graph.addNode(gNodeA);
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graphNodesMap.put("A", gNodeA);
-    
-    Mutation addA = Mutation.newBuilder()
-                        .setType(Mutation.Type.ADD_NODE)
-                        .setStartNode("A")
-                        .build();
 
-    
+    Mutation addA = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("A").build();
 
     boolean success = servlet.mutateGraph(addA, graph, graphNodesMap);
     Assert.assertFalse(success);
@@ -122,7 +103,7 @@ public final class MutationTest {
    */
   @Test
   public void addEdgeBasic() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -130,15 +111,12 @@ public final class MutationTest {
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
 
-
-    
-    Mutation addAB = Mutation.newBuilder()
-                        .setType(Mutation.Type.ADD_EDGE)
-                        .setStartNode("A")
-                        .setEndNode("B")
-                        .build();
-
-    
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
 
     boolean success = servlet.mutateGraph(addAB, graph, graphNodesMap);
     Assert.assertTrue(success);
@@ -159,7 +137,7 @@ public final class MutationTest {
    */
   @Test
   public void addEdgeError() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -168,15 +146,12 @@ public final class MutationTest {
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
 
-
-    
-    Mutation addAB = Mutation.newBuilder()
-                        .setType(Mutation.Type.ADD_EDGE)
-                        .setStartNode("A")
-                        .setEndNode("C")
-                        .build();
-
-    
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("C")
+            .build();
 
     boolean success = servlet.mutateGraph(addAB, graph, graphNodesMap);
     Assert.assertFalse(success);
@@ -196,7 +171,7 @@ public final class MutationTest {
    */
   @Test
   public void deleteNode() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -204,20 +179,12 @@ public final class MutationTest {
     graph.putEdge(gNodeA, gNodeB);
     graph.putEdge(gNodeB, gNodeC);
 
-
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
     graphNodesMap.put("C", gNodeC);
 
-
-
-    
-    Mutation removeA = Mutation.newBuilder()
-                        .setType(Mutation.Type.DELETE_NODE)
-                        .setStartNode("A")
-                        .build();
-
-    
+    Mutation removeA =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("A").build();
 
     boolean success = servlet.mutateGraph(removeA, graph, graphNodesMap);
     Assert.assertTrue(success);
@@ -233,25 +200,22 @@ public final class MutationTest {
     Assert.assertEquals(graph.outDegree(gNodeB), 1);
   }
 
-    /*
+  /*
    * Check that a deleting a non-existent node errors
    */
   @Test
   public void deleteAbsentNodeError() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
     graph.putEdge(gNodeA, gNodeB);
 
-
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
-    
-    Mutation removeC = Mutation.newBuilder()
-                        .setType(Mutation.Type.DELETE_NODE)
-                        .setStartNode("C")
-                        .build();
+
+    Mutation removeC =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
     boolean success = servlet.mutateGraph(removeC, graph, graphNodesMap);
     Assert.assertFalse(success);
@@ -265,13 +229,12 @@ public final class MutationTest {
     Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
   }
 
-
   /*
    * Check that an existing edge is correctly deleted
    */
   @Test
   public void deleteEdge() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -279,21 +242,16 @@ public final class MutationTest {
     graph.putEdge(gNodeA, gNodeB);
     graph.putEdge(gNodeB, gNodeC);
 
-
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
     graphNodesMap.put("C", gNodeC);
 
-
-
-    
-    Mutation removeAB = Mutation.newBuilder()
-                        .setType(Mutation.Type.DELETE_EDGE)
-                        .setStartNode("A")
-                        .setEndNode("B")
-                        .build();
-
-    
+    Mutation removeAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
 
     boolean success = servlet.mutateGraph(removeAB, graph, graphNodesMap);
     Assert.assertTrue(success);
@@ -317,20 +275,17 @@ public final class MutationTest {
    */
   @Test
   public void deleteAbsentEdgeError() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
     graph.putEdge(gNodeA, gNodeB);
 
-
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
-    
-    Mutation removeAX = Mutation.newBuilder()
-                        .setType(Mutation.Type.DELETE_EDGE)
-                        .setStartNode("A")
-                        .build();
+
+    Mutation removeAX =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").build();
 
     boolean success = servlet.mutateGraph(removeAX, graph, graphNodesMap);
     Assert.assertFalse(success);
@@ -349,7 +304,7 @@ public final class MutationTest {
    */
   @Test
   public void deleteAbsentEdgeSuccess() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -357,19 +312,16 @@ public final class MutationTest {
     graph.putEdge(gNodeA, gNodeB);
     graph.putEdge(gNodeB, gNodeC);
 
-
     graphNodesMap.put("A", gNodeA);
     graphNodesMap.put("B", gNodeB);
     graphNodesMap.put("C", gNodeC);
 
-    
-    Mutation removeAC = Mutation.newBuilder()
-                        .setType(Mutation.Type.DELETE_EDGE)
-                        .setStartNode("A")
-                        .setEndNode("C")
-                        .build();
-
-    
+    Mutation removeAC =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("A")
+            .setEndNode("C")
+            .build();
 
     boolean success = servlet.mutateGraph(removeAC, graph, graphNodesMap);
     Assert.assertTrue(success);
@@ -392,7 +344,7 @@ public final class MutationTest {
    */
   @Test
   public void addTokens() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -408,26 +360,23 @@ public final class MutationTest {
     newTokens.add("2");
     newTokens.add("3");
 
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
 
-    TokenMutation tokenMut = TokenMutation.newBuilder()
-                                .setType(TokenMutation.Type.ADD_TOKEN)
-                                .addTokenName("1")
-                                .addTokenName("2")
-                                .addTokenName("3")
-                                .build();
-
-    
-    Mutation addTokenToA = Mutation.newBuilder()
-                        .setStartNode("A")
-                        .setType(Mutation.Type.CHANGE_TOKEN)
-                        .setTokenChange(tokenMut)
-                        .build();
-
-    
+    Mutation addTokenToA =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
     boolean success = servlet.mutateGraph(addTokenToA, graph, graphNodesMap);
     Assert.assertTrue(success);
-
 
     Set<GraphNode> graphNodes = graph.nodes();
     Assert.assertTrue(graphNodesMap.containsKey("A"));
@@ -451,7 +400,7 @@ public final class MutationTest {
    */
   @Test
   public void removeTokens() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     nodeA.addToken("1");
     nodeA.addToken("2");
@@ -472,25 +421,22 @@ public final class MutationTest {
     newTokens.add("1");
     newTokens.add("3");
 
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.DELETE_TOKEN)
+            .addTokenName("2")
+            .addTokenName("4")
+            .build();
 
-    TokenMutation tokenMut = TokenMutation.newBuilder()
-                                .setType(TokenMutation.Type.DELETE_TOKEN)
-                                .addTokenName("2")
-                                .addTokenName("4")
-                                .build();
-
-    
-    Mutation removeTokenFromA = Mutation.newBuilder()
-                        .setStartNode("A")
-                        .setType(Mutation.Type.CHANGE_TOKEN)
-                        .setTokenChange(tokenMut)
-                        .build();
-
-    
+    Mutation removeTokenFromA =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
     boolean success = servlet.mutateGraph(removeTokenFromA, graph, graphNodesMap);
     Assert.assertTrue(success);
-
 
     Set<GraphNode> graphNodes = graph.nodes();
     Assert.assertTrue(graphNodesMap.containsKey("A"));
@@ -513,7 +459,7 @@ public final class MutationTest {
    */
   @Test
   public void invalidTokenMutation() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -524,23 +470,17 @@ public final class MutationTest {
     graphNodesMap.put("B", gNodeB);
     graphNodesMap.put("C", gNodeC);
 
-    TokenMutation tokenMut = TokenMutation.newBuilder()
-                                .addTokenName("2")
-                                .addTokenName("4")
-                                .build();
+    TokenMutation tokenMut = TokenMutation.newBuilder().addTokenName("2").addTokenName("4").build();
 
-    
-    Mutation addToA = Mutation.newBuilder()
-                        .setStartNode("A")
-                        .setType(Mutation.Type.CHANGE_TOKEN)
-                        .setTokenChange(tokenMut)
-                        .build();
-
-    
+    Mutation addToA =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
     boolean success = servlet.mutateGraph(addToA, graph, graphNodesMap);
     Assert.assertFalse(success);
-
 
     Set<GraphNode> graphNodes = graph.nodes();
     Assert.assertEquals(graphNodes.size(), 3);
@@ -560,7 +500,7 @@ public final class MutationTest {
    */
   @Test
   public void invalidNodeTokenMutation() {
-    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();
     HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
     graph.addNode(gNodeA);
     graph.addNode(gNodeB);
@@ -571,23 +511,18 @@ public final class MutationTest {
     graphNodesMap.put("B", gNodeB);
     graphNodesMap.put("C", gNodeC);
 
-    TokenMutation tokenMut = TokenMutation.newBuilder()
-                                .setType(TokenMutation.Type.ADD_TOKEN)
-                                .addTokenName("2")
-                                .addTokenName("4")
-                                .build();
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("2")
+            .addTokenName("4")
+            .build();
 
-    
-    Mutation add = Mutation.newBuilder()
-                        .setType(Mutation.Type.CHANGE_TOKEN)
-                        .setTokenChange(tokenMut)
-                        .build();
-
-    
+    Mutation add =
+        Mutation.newBuilder().setType(Mutation.Type.CHANGE_TOKEN).setTokenChange(tokenMut).build();
 
     boolean success = servlet.mutateGraph(add, graph, graphNodesMap);
     Assert.assertFalse(success);
-
 
     Set<GraphNode> graphNodes = graph.nodes();
     Assert.assertEquals(graphNodes.size(), 3);

--- a/src/test/java/com/google/sps/MutationTest.java
+++ b/src/test/java/com/google/sps/MutationTest.java
@@ -1,0 +1,604 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import com.google.common.graph.*;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.sps.servlets.DataServlet;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.Iterator;
+import com.google.sps.data.GraphNode;
+import com.proto.GraphProtos.Graph;
+import com.proto.GraphProtos.Node;
+import com.proto.GraphProtos.Node.Builder;
+import com.proto.MutationProtos.Mutation;
+import com.proto.MutationProtos.MutationList;
+import com.proto.MutationProtos.TokenMutation;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** */
+@RunWith(JUnit4.class)
+public final class MutationTest {
+
+  DataServlet servlet;
+
+  // Proto nodes to construct graph with
+  Builder nodeA = Node.newBuilder().setName("A");
+  Builder nodeB = Node.newBuilder().setName("B");
+  Builder nodeC = Node.newBuilder().setName("C");
+  Builder nodeD = Node.newBuilder().setName("D");
+  Builder nodeE = Node.newBuilder().setName("E");
+  Builder nodeF = Node.newBuilder().setName("F");
+
+
+  GraphNode gNodeA;
+  GraphNode gNodeB;
+  GraphNode gNodeC;
+  GraphNode gNodeD;
+  GraphNode gNodeE;
+  GraphNode gNodeF;
+
+
+
+  @Before
+  public void setUp() {
+    servlet = new DataServlet();
+    gNodeA = servlet.protoNodeToGraphNode(nodeA.build());
+    gNodeB = servlet.protoNodeToGraphNode(nodeB.build());
+    gNodeC = servlet.protoNodeToGraphNode(nodeC.build());
+    gNodeD = servlet.protoNodeToGraphNode(nodeD.build());
+    gNodeE = servlet.protoNodeToGraphNode(nodeE.build());
+    gNodeF = servlet.protoNodeToGraphNode(nodeF.build());
+  }
+
+  /*
+   * Check that a single node is correctly added to the graph
+   */
+  @Test
+  public void addNodeBasic() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    
+    Mutation addA = Mutation.newBuilder()
+                        .setType(Mutation.Type.ADD_NODE)
+                        .setStartNode("A")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addA, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 1);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+  }
+
+  /*
+   * Check that adding duplicate nodes is not allowed
+   */
+  @Test
+  public void noAddDuplicates() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();  
+    graph.addNode(gNodeA);    
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graphNodesMap.put("A", gNodeA);
+    
+    Mutation addA = Mutation.newBuilder()
+                        .setType(Mutation.Type.ADD_NODE)
+                        .setStartNode("A")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addA, graph, graphNodesMap);
+    Assert.assertFalse(success);
+  }
+
+  /*
+   * Check that a single edge is correctly added to the graph
+   */
+  @Test
+  public void addEdgeBasic() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+
+
+    
+    Mutation addAB = Mutation.newBuilder()
+                        .setType(Mutation.Type.ADD_EDGE)
+                        .setStartNode("A")
+                        .setEndNode("B")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addAB, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 2);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+    Assert.assertFalse(graph.hasEdgeConnecting(gNodeB, gNodeA));
+  }
+
+  /*
+   * Check that adding an edge to a non-existent node errors
+   */
+  @Test
+  public void addEdgeError() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.putEdge(gNodeA, gNodeB);
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+
+
+    
+    Mutation addAB = Mutation.newBuilder()
+                        .setType(Mutation.Type.ADD_EDGE)
+                        .setStartNode("A")
+                        .setEndNode("C")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addAB, graph, graphNodesMap);
+    Assert.assertFalse(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 2);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+  }
+
+  /*
+   * Check that an existing node and all adjacent edges are correctly deleted
+   */
+  @Test
+  public void deleteNode() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+
+
+    
+    Mutation removeA = Mutation.newBuilder()
+                        .setType(Mutation.Type.DELETE_NODE)
+                        .setStartNode("A")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(removeA, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 2);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertEquals(graph.inDegree(gNodeB), 0);
+    Assert.assertEquals(graph.outDegree(gNodeB), 1);
+  }
+
+    /*
+   * Check that a deleting a non-existent node errors
+   */
+  @Test
+  public void deleteAbsentNodeError() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.putEdge(gNodeA, gNodeB);
+
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    
+    Mutation removeC = Mutation.newBuilder()
+                        .setType(Mutation.Type.DELETE_NODE)
+                        .setStartNode("C")
+                        .build();
+
+    boolean success = servlet.mutateGraph(removeC, graph, graphNodesMap);
+    Assert.assertFalse(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 2);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+  }
+
+
+  /*
+   * Check that an existing edge is correctly deleted
+   */
+  @Test
+  public void deleteEdge() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+
+
+    
+    Mutation removeAB = Mutation.newBuilder()
+                        .setType(Mutation.Type.DELETE_EDGE)
+                        .setStartNode("A")
+                        .setEndNode("B")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(removeAB, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertEquals(graph.inDegree(gNodeB), 0);
+    Assert.assertEquals(graph.outDegree(gNodeB), 1);
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+  }
+
+  /*
+   * Check that a deleting an edge with no endpoint specified errors
+   */
+  @Test
+  public void deleteAbsentEdgeError() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.putEdge(gNodeA, gNodeB);
+
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    
+    Mutation removeAX = Mutation.newBuilder()
+                        .setType(Mutation.Type.DELETE_EDGE)
+                        .setStartNode("A")
+                        .build();
+
+    boolean success = servlet.mutateGraph(removeAX, graph, graphNodesMap);
+    Assert.assertFalse(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 2);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+  }
+
+  /*
+   * Check that a deleting an edge between unconnected nodes has no impact
+   */
+  @Test
+  public void deleteAbsentEdgeSuccess() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+
+
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+    
+    Mutation removeAC = Mutation.newBuilder()
+                        .setType(Mutation.Type.DELETE_EDGE)
+                        .setStartNode("A")
+                        .setEndNode("C")
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(removeAC, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), gNodeA);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+  }
+
+  /*
+   * Check that adding tokens to a node has the right effect
+   */
+  @Test
+  public void addTokens() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+    List<String> newTokens = new ArrayList<>();
+    newTokens.add("1");
+    newTokens.add("2");
+    newTokens.add("3");
+
+
+    TokenMutation tokenMut = TokenMutation.newBuilder()
+                                .setType(TokenMutation.Type.ADD_TOKEN)
+                                .addTokenName("1")
+                                .addTokenName("2")
+                                .addTokenName("3")
+                                .build();
+
+    
+    Mutation addTokenToA = Mutation.newBuilder()
+                        .setStartNode("A")
+                        .setType(Mutation.Type.CHANGE_TOKEN)
+                        .setTokenChange(tokenMut)
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addTokenToA, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertTrue(graphNodesMap.containsKey("A"));
+    GraphNode newNodeA = graphNodesMap.get("A");
+
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(newNodeA));
+    Assert.assertEquals(graphNodesMap.get("A"), newNodeA);
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(newNodeA, gNodeB));
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+    Assert.assertEquals(newNodeA.tokenList(), newTokens);
+  }
+
+  /*
+   * Check that removing tokens from a node has the right effect
+   */
+  @Test
+  public void removeTokens() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    nodeA.addToken("1");
+    nodeA.addToken("2");
+    nodeA.addToken("3");
+    nodeA.addToken("4");
+    gNodeA = servlet.protoNodeToGraphNode(nodeA.build());
+
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+    List<String> newTokens = new ArrayList<>();
+    newTokens.add("1");
+    newTokens.add("3");
+
+
+    TokenMutation tokenMut = TokenMutation.newBuilder()
+                                .setType(TokenMutation.Type.DELETE_TOKEN)
+                                .addTokenName("2")
+                                .addTokenName("4")
+                                .build();
+
+    
+    Mutation removeTokenFromA = Mutation.newBuilder()
+                        .setStartNode("A")
+                        .setType(Mutation.Type.CHANGE_TOKEN)
+                        .setTokenChange(tokenMut)
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(removeTokenFromA, graph, graphNodesMap);
+    Assert.assertTrue(success);
+
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertTrue(graphNodesMap.containsKey("A"));
+    GraphNode newNodeA = graphNodesMap.get("A");
+
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(newNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(newNodeA, gNodeB));
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+    Assert.assertEquals(newNodeA.tokenList(), newTokens);
+  }
+
+  /*
+   * Check that not specifying the token mutation type errors
+   */
+  @Test
+  public void invalidTokenMutation() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+    TokenMutation tokenMut = TokenMutation.newBuilder()
+                                .addTokenName("2")
+                                .addTokenName("4")
+                                .build();
+
+    
+    Mutation addToA = Mutation.newBuilder()
+                        .setStartNode("A")
+                        .setType(Mutation.Type.CHANGE_TOKEN)
+                        .setTokenChange(tokenMut)
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(addToA, graph, graphNodesMap);
+    Assert.assertFalse(success);
+
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodesMap.containsKey("A"));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+  }
+
+  /*
+   * Check that not specifying node to be mutated errors
+   */
+  @Test
+  public void invalidNodeTokenMutation() {
+    MutableGraph<GraphNode> graph = GraphBuilder.directed().build();      
+    HashMap<String, GraphNode> graphNodesMap = new HashMap<>();
+    graph.addNode(gNodeA);
+    graph.addNode(gNodeB);
+    graph.addNode(gNodeC);
+    graph.putEdge(gNodeA, gNodeB);
+    graph.putEdge(gNodeB, gNodeC);
+    graphNodesMap.put("A", gNodeA);
+    graphNodesMap.put("B", gNodeB);
+    graphNodesMap.put("C", gNodeC);
+
+    TokenMutation tokenMut = TokenMutation.newBuilder()
+                                .setType(TokenMutation.Type.ADD_TOKEN)
+                                .addTokenName("2")
+                                .addTokenName("4")
+                                .build();
+
+    
+    Mutation add = Mutation.newBuilder()
+                        .setType(Mutation.Type.CHANGE_TOKEN)
+                        .setTokenChange(tokenMut)
+                        .build();
+
+    
+
+    boolean success = servlet.mutateGraph(add, graph, graphNodesMap);
+    Assert.assertFalse(success);
+
+
+    Set<GraphNode> graphNodes = graph.nodes();
+    Assert.assertEquals(graphNodes.size(), 3);
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodesMap.containsKey("A"));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertEquals(graphNodesMap.get("B"), gNodeB);
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertEquals(graphNodesMap.get("C"), gNodeC);
+
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeA, gNodeB));
+    Assert.assertTrue(graph.hasEdgeConnecting(gNodeB, gNodeC));
+  }
+}

--- a/src/test/java/com/google/sps/MutationTest.java
+++ b/src/test/java/com/google/sps/MutationTest.java
@@ -382,6 +382,7 @@ public final class MutationTest {
     Assert.assertTrue(graphNodesMap.containsKey("A"));
     GraphNode newNodeA = graphNodesMap.get("A");
 
+    Assert.assertSame(gNodeA, newNodeA);
     Assert.assertEquals(graphNodes.size(), 3);
     Assert.assertTrue(graphNodes.contains(newNodeA));
     Assert.assertEquals(graphNodesMap.get("A"), newNodeA);
@@ -442,6 +443,7 @@ public final class MutationTest {
     Assert.assertTrue(graphNodesMap.containsKey("A"));
     GraphNode newNodeA = graphNodesMap.get("A");
 
+    Assert.assertSame(gNodeA, newNodeA);
     Assert.assertEquals(graphNodes.size(), 3);
     Assert.assertTrue(graphNodes.contains(newNodeA));
     Assert.assertTrue(graphNodes.contains(gNodeB));


### PR DESCRIPTION
In this PR, we:
- added unit tests to verify that the Guava graph was correctly being generated from a proto string-Node map
- added unit tests to verify that our code for processing various mutations was correct.