### PR TITLE
Implement search on the backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
-      <!-- <scope>test</scope> -->
+      <!-- The following line is commented out because the tests weren't working for me with it -->
+      <!-- <scope>test</scope> --> 
     </dependency>
 
     <dependency>

--- a/spec/jstests-spec.js
+++ b/spec/jstests-spec.js
@@ -305,8 +305,6 @@ describe("Check correct url params", function() {
   })
 });
 
-});
-
 describe("Node search", function() {
   const cy = cytoscape({ 
     elements: [
@@ -342,5 +340,3 @@ describe("Node search", function() {
     expect(result).toBe(false);
   });
 });
-
-

--- a/spec/jstests-spec.js
+++ b/spec/jstests-spec.js
@@ -262,13 +262,17 @@ describe("Pressing next and previous buttons associated with a graph", function(
   });
 });
 
-describe("Check initializing variables are passed correctly", function() {
+describe("Check correct url params", function() {
+  let nodeName = {}; 
   beforeEach(function() {
     setCurrGraphNum(1);
+    nodeName = document.createElement("input");
+    nodeName.id = "node-name";
   });
 
   afterEach(function() {
     setCurrGraphNum(0);
+     document.body.innerHTML = '';
   });
 
   it("passes correct value of the mutations number in the fetch request", function() {
@@ -280,5 +284,20 @@ describe("Check initializing variables are passed correctly", function() {
     expect(constructedUrl.get("depth")).toBe("3");
     expect(constructedUrl.has("mutationNum")).toBe(true);
     expect(constructedUrl.get("mutationNum")).toBe("1");
+
+    // Not on page here, should be empty
+    expect(constructedUrl.has("nodeName")).toBe(true);
+    expect(constructedUrl.get("nodeName")).toBe("");
   });
+  it ("passes correct nodeName when nodeName has a value", function () {
+    nodeName.value = "A";
+    document.body.appendChild(nodeName);
+
+    const requestString = getUrl();
+    const requestParams = requestString.substring(requestString.indexOf("?"));
+
+    const constructedUrl = new URLSearchParams(requestParams);
+    expect(constructedUrl.has("nodeName")).toBe(true);
+    expect(constructedUrl.get("nodeName")).toBe("A"); 
+  })
 });

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -21,6 +21,7 @@ import com.proto.GraphProtos.Node;
 import com.proto.MutationProtos.Mutation;
 import com.proto.MutationProtos.TokenMutation;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,28 +38,22 @@ abstract class DataGraph {
    * @return the empty data graph with these attributes
    */
   public static DataGraph create() {
-    return new AutoValue_DataGraph(
-        GraphBuilder.directed().build(),
-        new HashMap<String, GraphNode>(),
-        new HashSet<String>(),
-        0);
+    return new AutoValue_DataGraph(GraphBuilder.directed().build(), new HashMap<String, GraphNode>(),
+        new HashSet<String>(), 0);
   }
 
   /**
    * Create a new data graph with the given attributes
    *
-   * @param graph the guava graph
+   * @param graph         the guava graph
    * @param graphNodesMap the map from node name to node
-   * @param roots a set of roots (nodes with no in-edges) of the graph
-   * @param numMutations the maximum number of mutations in the list of mutations this graph is an
-   *     intermediate result of applyiing
+   * @param roots         a set of roots (nodes with no in-edges) of the graph
+   * @param numMutations  the maximum number of mutations in the list of mutations
+   *                      this graph is an intermediate result of applyiing
    * @return the data graph with these attributes
    */
-  static DataGraph create(
-      MutableGraph<GraphNode> graph,
-      HashMap<String, GraphNode> graphNodesMap,
-      HashSet<String> roots,
-      int numMutations) {
+  static DataGraph create(MutableGraph<GraphNode> graph, HashMap<String, GraphNode> graphNodesMap,
+      HashSet<String> roots, int numMutations) {
     return new AutoValue_DataGraph(graph, graphNodesMap, roots, numMutations);
   }
 
@@ -111,10 +106,11 @@ abstract class DataGraph {
   }
 
   /**
-   * Takes in a map from node name to proto-parsed node object. Populates data graph with
-   * information from the parsed graph
+   * Takes in a map from node name to proto-parsed node object. Populates data
+   * graph with information from the parsed graph
    *
-   * @param protoNodesMap map from node name to proto Node object parsed from input
+   * @param protoNodesMap map from node name to proto Node object parsed from
+   *                      input
    * @return false if an error occurred, true otherwise
    */
   boolean graphFromProtoNodes(Map<String, Node> protoNodesMap) {
@@ -183,8 +179,7 @@ abstract class DataGraph {
           // New lone node is a root
           roots.add(startName);
           // Create a new node with the given name and add it to the graph and the map
-          GraphNode newGraphNode =
-              GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
+          GraphNode newGraphNode = GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
           graph.addNode(newGraphNode);
           graphNodesMap.put(startName, newGraphNode);
         }
@@ -254,10 +249,12 @@ abstract class DataGraph {
     }
     return true;
   }
+
   /**
-   * Modifies the list of tokens of this node to either add or remove tokens contained in tokenMut
+   * Modifies the list of tokens of this node to either add or remove tokens
+   * contained in tokenMut
    *
-   * @param node the node whose token list should be modified
+   * @param node     the node whose token list should be modified
    * @param tokenMut the mutation that should be applied to the token list
    * @return the new GraphNode object, or null if it's an unrecognized mutation
    */
@@ -283,7 +280,8 @@ abstract class DataGraph {
   }
 
   /**
-   * Function for calculating nodes reachable from roots of this graph within at most maxDepth steps
+   * Function for calculating nodes reachable from roots of this graph within at
+   * most maxDepth steps
    *
    * @param maxDepth the maximum depth of a node from a root
    * @return a graph with nodes only a certain distance from a root
@@ -308,13 +306,14 @@ abstract class DataGraph {
   }
 
   /**
-   * Helper function for performing a depth-first traversal of the graph starting at node and adding
-   * all those nodes to visited which are within depthRemaining steps from the node
+   * Helper function for performing a depth-first traversal of the graph starting
+   * at node and adding all those nodes to visited which are within depthRemaining
+   * steps from the node
    *
-   * @param gn the GraphNode to start at
-   * @param visited a map that records whether nodes have been visited
-   * @param depthRemaining the number of layers left to explore, decreases by one with each
-   *     recursive call on a child
+   * @param gn             the GraphNode to start at
+   * @param visited        a map that records whether nodes have been visited
+   * @param depthRemaining the number of layers left to explore, decreases by one
+   *                       with each recursive call on a child
    */
   private void dfsVisit(GraphNode gn, Map<GraphNode, Boolean> visited, int depthRemaining) {
     MutableGraph<GraphNode> graph = this.graph();
@@ -327,5 +326,57 @@ abstract class DataGraph {
         }
       }
     }
+  }
+
+  /**
+   * Returns a MutableGraph with nodes that are at most a certain radius from a given node
+   * If the radius is less than 0 or the node specified isn't present, return an emptu graph
+   * Since maxDepth was implemented as DFS, we use BFS for *diversity*
+   * 
+   * @param name the name of the node to search for
+   * @param radius the distance from the node to search for parents and children
+   * @return a graph comprised of only nodes and edges within a certain distance from the specified node
+   */
+  public MutableGraph<GraphNode> nodeSearch(String name, int radius) {
+    if (radius < 0) {
+      return GraphBuilder.directed().build(); // If max depth below 0, then return an emtpy graph
+    }
+
+    HashMap<String, GraphNode> graphNodesMap = this.graphNodesMap();
+    if (graphNodesMap.containsKey(name)) {
+      return GraphBuilder.directed().build(); // If the specified node is not found, return an empty graph
+    }
+
+    MutableGraph<GraphNode> graph = this.graph();
+    GraphNode tgtNode = graphNodesMap.get(name);
+
+    Map<GraphNode, Boolean> visited = new HashMap<>();
+    HashSet<GraphNode> nextLayer;
+    ArrayDeque<GraphNode> queue = new ArrayDeque<GraphNode>();
+
+    queue.add(tgtNode); // Adds the searched node to the queue
+
+    for (int i = 0; i < radius; i++) {
+      nextLayer = new HashSet<>();
+      while (!queue.isEmpty()) {
+        GraphNode curr = queue.poll();
+        if (!visited.containsKey(curr)) {
+          visited.put(curr, true);
+
+          for (GraphNode child : graph.successors(curr)) {
+            if (!visited.containsKey(child)) {
+              nextLayer.add(child);
+            }
+          }
+          for (GraphNode parent : graph.predecessors(curr)) {
+            nextLayer.add(parent);
+          }
+        }
+      }
+      queue.addAll(nextLayer);
+    }
+    MutableGraph<GraphNode> graphToReturn = Graphs.inducedSubgraph(graph, visited.keySet());
+
+    return graphToReturn;
   }
 }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -381,7 +381,6 @@ abstract class DataGraph {
 
           // Adds the children
           for (GraphNode child : graph.successors(curr)) {
-            System.out.println(child);
             if (!visited.containsKey(child)) {
               nextLayer.add(child);
             }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -422,7 +422,7 @@ abstract class DataGraph {
           }
         } else {
           // Adds the parents
-          for (GraphNode parent : graph().predecessors(curr)) {
+          for (GraphNode parent : this.graph().predecessors(curr)) {
             if (!visited.contains(parent)) {
               nextLayer.add(parent);
             }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -352,24 +352,32 @@ abstract class DataGraph {
 
     Map<GraphNode, Boolean> visited = new HashMap<>();
     HashSet<GraphNode> nextLayer;
-    ArrayDeque<GraphNode> queue = new ArrayDeque<GraphNode>();
+    ArrayDeque<GraphNode> queue = new ArrayDeque<>();
 
     queue.add(tgtNode); // Adds the searched node to the queue
 
     for (int i = 0; i < radius; i++) {
+      if (queue.isEmpty()) {
+        break;
+      }
       nextLayer = new HashSet<>();
       while (!queue.isEmpty()) {
         GraphNode curr = queue.poll();
+
         if (!visited.containsKey(curr)) {
           visited.put(curr, true);
 
+          // Adds the children
           for (GraphNode child : graph.successors(curr)) {
             if (!visited.containsKey(child)) {
               nextLayer.add(child);
             }
           }
+          // Adds the parents
           for (GraphNode parent : graph.predecessors(curr)) {
-            nextLayer.add(parent);
+            if (!visited.containsKey(parent)) {
+              nextLayer.add(parent);
+            }
           }
         }
       }
@@ -379,4 +387,5 @@ abstract class DataGraph {
 
     return graphToReturn;
   }
+
 }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -356,19 +356,21 @@ abstract class DataGraph {
 
     MutableGraph<GraphNode> graph = this.graph();
     GraphNode tgtNode = graphNodesMap.get(name);
+    
     if (tgtNode == null) {
       System.out.println("it should not be getting here bc this is a useless check");
       return getGraphWithMaxDepth(radius);
     }
 
     Map<GraphNode, Boolean> visited = new HashMap<>();
+    
     HashSet<GraphNode> nextLayer;
     ArrayDeque<GraphNode> queue = new ArrayDeque<>();
 
     queue.add(tgtNode); // Adds the searched node to the queue
-
-    for (int i = 0; i < radius; i++) {
-      if (queue.isEmpty()) {
+ 
+    for (int i = 0; i <= radius; i++) {
+      if (queue.size() == 0) {
         break;
       }
       nextLayer = new HashSet<>();

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -370,6 +370,7 @@ abstract class DataGraph {
     queue.add(tgtNode); // Adds the searched node to the queue
  
     for (int i = 0; i <= radius; i++) {
+      // Break out early if queue is empty
       if (queue.size() == 0) {
         break;
       }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -332,8 +332,8 @@ abstract class DataGraph {
 
   /**
    * Returns a MutableGraph with nodes that are at most a certain radius from a given node. If the
-   * radius is less than 0 or the node specified isn't present, return an empty graph. Since maxDepth
-   * was implemented as DFS, we use BFS for *diversity*
+   * radius is less than 0 or the node specified isn't present, return an empty graph. Since
+   * maxDepth was implemented as DFS, we use BFS for *diversity*
    *
    * @param name the name of the node to search for
    * @param radius the distance from the node to search for parents and children

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -348,18 +348,12 @@ abstract class DataGraph {
     HashMap<String, GraphNode> graphNodesMap = this.graphNodesMap();
 
     if (!graphNodesMap.containsKey(name)) {
-      System.out.println("it should not be getting here bc it should contain the key");
       return GraphBuilder.directed()
           .build(); // If the specified node is not found, return an empty graph
     }
 
     MutableGraph<GraphNode> graph = this.graph();
     GraphNode tgtNode = graphNodesMap.get(name);
-
-    if (tgtNode == null) {
-      System.out.println("it should not be getting here bc this is a useless check");
-      return getGraphWithMaxDepth(radius);
-    }
 
     Map<GraphNode, Boolean> visited = new HashMap<>();
 

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -337,7 +337,7 @@ abstract class DataGraph {
    * @param radius the distance from the node to search for parents and children
    * @return a graph comprised of only nodes and edges within a certain distance from the specified node
    */
-  public MutableGraph<GraphNode> nodeSearch(String name, int radius) {
+  public MutableGraph<GraphNode> getReachableNodes(String name, int radius) {
     if (radius < 0) {
       return GraphBuilder.directed().build(); // If max depth below 0, then return an emtpy graph
     }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -38,23 +38,27 @@ abstract class DataGraph {
    * @return the empty data graph with these attributes
    */
   public static DataGraph create() {
-    return new AutoValue_DataGraph(/* graph = */ GraphBuilder.directed().build(),
-        /* graphNodesMap = */ new HashMap<String, GraphNode>(), /* roots = */ new HashSet<String>(),
+    return new AutoValue_DataGraph(
+        /* graph = */ GraphBuilder.directed().build(),
+        /* graphNodesMap = */ new HashMap<String, GraphNode>(),
+        /* roots = */ new HashSet<String>(),
         /* numMutations = */ 0);
   }
 
   /**
    * Create a new data graph with the given attributes
    *
-   * @param graph         the guava graph
+   * @param graph the guava graph
    * @param graphNodesMap the map from node name to node
-   * @param roots         a set of roots (nodes with no in-edges) of the graph
-   * @param numMutations  the number of mutations applied to the initial graph to
-   *                      get this graph
+   * @param roots a set of roots (nodes with no in-edges) of the graph
+   * @param numMutations the number of mutations applied to the initial graph to get this graph
    * @return the data graph with these attributes
    */
-  static DataGraph create(MutableGraph<GraphNode> graph, HashMap<String, GraphNode> graphNodesMap,
-      HashSet<String> roots, int numMutations) {
+  static DataGraph create(
+      MutableGraph<GraphNode> graph,
+      HashMap<String, GraphNode> graphNodesMap,
+      HashSet<String> roots,
+      int numMutations) {
     return new AutoValue_DataGraph(graph, graphNodesMap, roots, numMutations);
   }
 
@@ -82,16 +86,14 @@ abstract class DataGraph {
   /**
    * Getter for the number of mutations
    *
-   * @return the the number of mutations applied to the initial graph to get this
-   *         graph
+   * @return the the number of mutations applied to the initial graph to get this graph
    */
   abstract int numMutations();
 
   /**
    * Return a shallow copy of the given data graph
    *
-   * @return a shallow copy of the given data graph containing shallow copies of
-   *         its attributes
+   * @return a shallow copy of the given data graph containing shallow copies of its attributes
    */
   public DataGraph getCopy() {
     MutableGraph<GraphNode> graph = this.graph();
@@ -109,11 +111,10 @@ abstract class DataGraph {
   }
 
   /**
-   * Takes in a map from node name to proto-parsed node object. Populates data
-   * graph with information from the parsed graph
+   * Takes in a map from node name to proto-parsed node object. Populates data graph with
+   * information from the parsed graph
    *
-   * @param protoNodesMap map from node name to proto Node object parsed from
-   *                      input
+   * @param protoNodesMap map from node name to proto Node object parsed from input
    * @return false if an error occurred, true otherwise
    */
   boolean graphFromProtoNodes(Map<String, Node> protoNodesMap) {
@@ -182,7 +183,8 @@ abstract class DataGraph {
           // New lone node is a root
           roots.add(startName);
           // Create a new node with the given name and add it to the graph and the map
-          GraphNode newGraphNode = GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
+          GraphNode newGraphNode =
+              GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
           graph.addNode(newGraphNode);
           graphNodesMap.put(startName, newGraphNode);
         }
@@ -254,10 +256,9 @@ abstract class DataGraph {
   }
 
   /**
-   * Modifies the list of tokens of this node to either add or remove tokens
-   * contained in tokenMut
+   * Modifies the list of tokens of this node to either add or remove tokens contained in tokenMut
    *
-   * @param node     the node whose token list should be modified
+   * @param node the node whose token list should be modified
    * @param tokenMut the mutation that should be applied to the token list
    * @return the new GraphNode object, or null if it's an unrecognized mutation
    */
@@ -283,8 +284,7 @@ abstract class DataGraph {
   }
 
   /**
-   * Function for calculating nodes reachable from roots of this graph within at
-   * most maxDepth steps
+   * Function for calculating nodes reachable from roots of this graph within at most maxDepth steps
    *
    * @param maxDepth the maximum depth of a node from a root
    * @return a graph with nodes only a certain distance from a root
@@ -309,14 +309,13 @@ abstract class DataGraph {
   }
 
   /**
-   * Helper function for performing a depth-first traversal of the graph starting
-   * at node and adding all those nodes to visited which are within depthRemaining
-   * steps from the node
+   * Helper function for performing a depth-first traversal of the graph starting at node and adding
+   * all those nodes to visited which are within depthRemaining steps from the node
    *
-   * @param gn             the GraphNode to start at
-   * @param visited        a map that records whether nodes have been visited
-   * @param depthRemaining the number of layers left to explore, decreases by one
-   *                       with each recursive call on a child
+   * @param gn the GraphNode to start at
+   * @param visited a map that records whether nodes have been visited
+   * @param depthRemaining the number of layers left to explore, decreases by one with each
+   *     recursive call on a child
    */
   private void dfsVisit(GraphNode gn, Map<GraphNode, Boolean> visited, int depthRemaining) {
     MutableGraph<GraphNode> graph = this.graph();
@@ -332,18 +331,16 @@ abstract class DataGraph {
   }
 
   /**
-   * Returns a MutableGraph with nodes that are at most a certain radius from a
-   * given node. If the radius is less than 0 or the node specified isn't present,
-   * return an empty graph. Since maxDepth was implemented as DFS, we use BFS for
-   * *diversity*.
-   * 
-   * Here, we only consider children of children and parents of parents.
+   * Returns a MutableGraph with nodes that are at most a certain radius from a given node. If the
+   * radius is less than 0 or the node specified isn't present, return an empty graph. Since
+   * maxDepth was implemented as DFS, we use BFS for *diversity*.
    *
-   * @param name   the name of the node to search for
+   * <p>Here, we only consider children of children and parents of parents.
+   *
+   * @param name the name of the node to search for
    * @param radius the distance from the node to search for parents and children
-   * @return a graph comprised of only nodes and edges within a certain distance
-   *         from the specified node. Empty if radius is less than 0 or if the
-   *         node isn't found.
+   * @return a graph comprised of only nodes and edges within a certain distance from the specified
+   *     node. Empty if radius is less than 0 or if the node isn't found.
    */
   public MutableGraph<GraphNode> getReachableNodes(String name, int radius) {
     if (radius < 0) {
@@ -353,7 +350,8 @@ abstract class DataGraph {
     HashMap<String, GraphNode> graphNodesMap = this.graphNodesMap();
 
     if (!graphNodesMap.containsKey(name)) {
-      return GraphBuilder.directed().build(); // If the specified node is not found, return an empty graph
+      return GraphBuilder.directed()
+          .build(); // If the specified node is not found, return an empty graph
     }
 
     MutableGraph<GraphNode> graph = this.graph();
@@ -397,16 +395,17 @@ abstract class DataGraph {
   }
 
   /**
-   * Helper function that gets the next layer of nodes based on what's visited, a
-   * queue, and whether we're looking for children
-   * 
+   * Helper function that gets the next layer of nodes based on what's visited, a queue, and whether
+   * we're looking for children
+   *
    * @param visited A Hashset of visited nodes
-   * @param queue   the queue of nodes to visit in the current layer
-   * @param isChild whether we're looking for children. True means we look for the
-   *                children, and False means we look for parents.
+   * @param queue the queue of nodes to visit in the current layer
+   * @param isChild whether we're looking for children. True means we look for the children, and
+   *     False means we look for parents.
    * @return the nodes relevant to the next layer
    */
-  private HashSet<GraphNode> getNextLayer(HashSet<GraphNode> visited, ArrayDeque<GraphNode> queue, boolean isChild) {
+  private HashSet<GraphNode> getNextLayer(
+      HashSet<GraphNode> visited, ArrayDeque<GraphNode> queue, boolean isChild) {
     HashSet<GraphNode> nextLayer = new HashSet<>();
     while (!queue.isEmpty()) {
       GraphNode curr = queue.poll();
@@ -429,7 +428,6 @@ abstract class DataGraph {
             }
           }
         }
-
       }
     }
     return nextLayer;

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -345,15 +345,22 @@ abstract class DataGraph {
     if (radius < 0) {
       return GraphBuilder.directed().build(); // If max depth below 0, then return an emtpy graph
     }
-
+    
     HashMap<String, GraphNode> graphNodesMap = this.graphNodesMap();
-    if (graphNodesMap.containsKey(name)) {
+
+    if (!graphNodesMap.containsKey(name)) {
+      System.out.println("it should not be getting here bc it should contain the key");   
       return GraphBuilder.directed()
           .build(); // If the specified node is not found, return an empty graph
+       
     }
 
     MutableGraph<GraphNode> graph = this.graph();
     GraphNode tgtNode = graphNodesMap.get(name);
+    if (tgtNode == null) {
+      System.out.println("it should not be getting here bc this is a useless check");
+      return getGraphWithMaxDepth(radius);
+    }
 
     Map<GraphNode, Boolean> visited = new HashMap<>();
     HashSet<GraphNode> nextLayer;
@@ -374,6 +381,7 @@ abstract class DataGraph {
 
           // Adds the children
           for (GraphNode child : graph.successors(curr)) {
+            System.out.println(child);
             if (!visited.containsKey(child)) {
               nextLayer.add(child);
             }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -38,27 +38,23 @@ abstract class DataGraph {
    * @return the empty data graph with these attributes
    */
   public static DataGraph create() {
-    return new AutoValue_DataGraph(
-        /* graph = */ GraphBuilder.directed().build(),
-        /* graphNodesMap = */ new HashMap<String, GraphNode>(),
-        /* roots = */ new HashSet<String>(),
+    return new AutoValue_DataGraph(/* graph = */ GraphBuilder.directed().build(),
+        /* graphNodesMap = */ new HashMap<String, GraphNode>(), /* roots = */ new HashSet<String>(),
         /* numMutations = */ 0);
   }
 
   /**
    * Create a new data graph with the given attributes
    *
-   * @param graph the guava graph
+   * @param graph         the guava graph
    * @param graphNodesMap the map from node name to node
-   * @param roots a set of roots (nodes with no in-edges) of the graph
-   * @param numMutations the number of mutations applied to the initial graph to get this graph
+   * @param roots         a set of roots (nodes with no in-edges) of the graph
+   * @param numMutations  the number of mutations applied to the initial graph to
+   *                      get this graph
    * @return the data graph with these attributes
    */
-  static DataGraph create(
-      MutableGraph<GraphNode> graph,
-      HashMap<String, GraphNode> graphNodesMap,
-      HashSet<String> roots,
-      int numMutations) {
+  static DataGraph create(MutableGraph<GraphNode> graph, HashMap<String, GraphNode> graphNodesMap,
+      HashSet<String> roots, int numMutations) {
     return new AutoValue_DataGraph(graph, graphNodesMap, roots, numMutations);
   }
 
@@ -86,14 +82,16 @@ abstract class DataGraph {
   /**
    * Getter for the number of mutations
    *
-   * @return the the number of mutations applied to the initial graph to get this graph
+   * @return the the number of mutations applied to the initial graph to get this
+   *         graph
    */
   abstract int numMutations();
 
   /**
    * Return a shallow copy of the given data graph
    *
-   * @return a shallow copy of the given data graph containing shallow copies of its attributes
+   * @return a shallow copy of the given data graph containing shallow copies of
+   *         its attributes
    */
   public DataGraph getCopy() {
     MutableGraph<GraphNode> graph = this.graph();
@@ -111,10 +109,11 @@ abstract class DataGraph {
   }
 
   /**
-   * Takes in a map from node name to proto-parsed node object. Populates data graph with
-   * information from the parsed graph
+   * Takes in a map from node name to proto-parsed node object. Populates data
+   * graph with information from the parsed graph
    *
-   * @param protoNodesMap map from node name to proto Node object parsed from input
+   * @param protoNodesMap map from node name to proto Node object parsed from
+   *                      input
    * @return false if an error occurred, true otherwise
    */
   boolean graphFromProtoNodes(Map<String, Node> protoNodesMap) {
@@ -183,8 +182,7 @@ abstract class DataGraph {
           // New lone node is a root
           roots.add(startName);
           // Create a new node with the given name and add it to the graph and the map
-          GraphNode newGraphNode =
-              GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
+          GraphNode newGraphNode = GraphNode.create(startName, new ArrayList<>(), Struct.newBuilder().build());
           graph.addNode(newGraphNode);
           graphNodesMap.put(startName, newGraphNode);
         }
@@ -256,9 +254,10 @@ abstract class DataGraph {
   }
 
   /**
-   * Modifies the list of tokens of this node to either add or remove tokens contained in tokenMut
+   * Modifies the list of tokens of this node to either add or remove tokens
+   * contained in tokenMut
    *
-   * @param node the node whose token list should be modified
+   * @param node     the node whose token list should be modified
    * @param tokenMut the mutation that should be applied to the token list
    * @return the new GraphNode object, or null if it's an unrecognized mutation
    */
@@ -284,7 +283,8 @@ abstract class DataGraph {
   }
 
   /**
-   * Function for calculating nodes reachable from roots of this graph within at most maxDepth steps
+   * Function for calculating nodes reachable from roots of this graph within at
+   * most maxDepth steps
    *
    * @param maxDepth the maximum depth of a node from a root
    * @return a graph with nodes only a certain distance from a root
@@ -309,13 +309,14 @@ abstract class DataGraph {
   }
 
   /**
-   * Helper function for performing a depth-first traversal of the graph starting at node and adding
-   * all those nodes to visited which are within depthRemaining steps from the node
+   * Helper function for performing a depth-first traversal of the graph starting
+   * at node and adding all those nodes to visited which are within depthRemaining
+   * steps from the node
    *
-   * @param gn the GraphNode to start at
-   * @param visited a map that records whether nodes have been visited
-   * @param depthRemaining the number of layers left to explore, decreases by one with each
-   *     recursive call on a child
+   * @param gn             the GraphNode to start at
+   * @param visited        a map that records whether nodes have been visited
+   * @param depthRemaining the number of layers left to explore, decreases by one
+   *                       with each recursive call on a child
    */
   private void dfsVisit(GraphNode gn, Map<GraphNode, Boolean> visited, int depthRemaining) {
     MutableGraph<GraphNode> graph = this.graph();
@@ -331,14 +332,18 @@ abstract class DataGraph {
   }
 
   /**
-   * Returns a MutableGraph with nodes that are at most a certain radius from a given node. If the
-   * radius is less than 0 or the node specified isn't present, return an empty graph. Since
-   * maxDepth was implemented as DFS, we use BFS for *diversity*
+   * Returns a MutableGraph with nodes that are at most a certain radius from a
+   * given node. If the radius is less than 0 or the node specified isn't present,
+   * return an empty graph. Since maxDepth was implemented as DFS, we use BFS for
+   * *diversity*.
+   * 
+   * Here, we only consider children of children and parents of parents.
    *
-   * @param name the name of the node to search for
+   * @param name   the name of the node to search for
    * @param radius the distance from the node to search for parents and children
-   * @return a graph comprised of only nodes and edges within a certain distance from the specified
-   *     node. Empty if radius is less than 0 or if the node isn't found.
+   * @return a graph comprised of only nodes and edges within a certain distance
+   *         from the specified node. Empty if radius is less than 0 or if the
+   *         node isn't found.
    */
   public MutableGraph<GraphNode> getReachableNodes(String name, int radius) {
     if (radius < 0) {
@@ -348,50 +353,85 @@ abstract class DataGraph {
     HashMap<String, GraphNode> graphNodesMap = this.graphNodesMap();
 
     if (!graphNodesMap.containsKey(name)) {
-      return GraphBuilder.directed()
-          .build(); // If the specified node is not found, return an empty graph
+      return GraphBuilder.directed().build(); // If the specified node is not found, return an empty graph
     }
 
     MutableGraph<GraphNode> graph = this.graph();
     GraphNode tgtNode = graphNodesMap.get(name);
 
-    Map<GraphNode, Boolean> visited = new HashMap<>();
+    // HashSet should have expected O(1) lookup, changed from HashMap for space
+    // Two different sets are needed because of cases where a node is both a parents
+    // and a child
+    HashSet<GraphNode> visitedChildren = new HashSet<>();
+    HashSet<GraphNode> visitedParents = new HashSet<>();
 
-    HashSet<GraphNode> nextLayer;
-    ArrayDeque<GraphNode> queue = new ArrayDeque<>();
+    HashSet<GraphNode> nextLayerChildren;
+    HashSet<GraphNode> nextLayerParents;
 
-    queue.add(tgtNode); // Adds the searched node to the queue
+    ArrayDeque<GraphNode> queueChildren = new ArrayDeque<>();
+    ArrayDeque<GraphNode> queueParents = new ArrayDeque<>();
+
+    queueChildren.add(tgtNode); // Adds the searched node to the queue
+    queueParents.add(tgtNode);
 
     for (int i = 0; i <= radius; i++) {
       // Break out early if queue is empty
-      if (queue.size() == 0) {
+      if (queueChildren.isEmpty() && queueParents.isEmpty()) {
         break;
       }
-      nextLayer = new HashSet<>();
-      while (!queue.isEmpty()) {
-        GraphNode curr = queue.poll();
 
-        if (!visited.containsKey(curr)) {
-          visited.put(curr, true);
+      // Helper function used to avoid duplicate code
+      nextLayerChildren = getNextLayer(visitedChildren, queueChildren, true);
+      nextLayerParents = getNextLayer(visitedParents, queueParents, false);
 
+      queueChildren.addAll(nextLayerChildren);
+      queueParents.addAll(nextLayerParents);
+    }
+
+    HashSet<GraphNode> visited = new HashSet<>();
+    visited.addAll(visitedChildren);
+    visited.addAll(visitedParents);
+    MutableGraph<GraphNode> graphToReturn = Graphs.inducedSubgraph(graph, visited);
+
+    return graphToReturn;
+  }
+
+  /**
+   * Helper function that gets the next layer of nodes based on what's visited, a
+   * queue, and whether we're looking for children
+   * 
+   * @param visited A Hashset of visited nodes
+   * @param queue   the queue of nodes to visit in the current layer
+   * @param isChild whether we're looking for children. True means we look for the
+   *                children, and False means we look for parents.
+   * @return the nodes relevant to the next layer
+   */
+  private HashSet<GraphNode> getNextLayer(HashSet<GraphNode> visited, ArrayDeque<GraphNode> queue, boolean isChild) {
+    HashSet<GraphNode> nextLayer = new HashSet<>();
+    while (!queue.isEmpty()) {
+      GraphNode curr = queue.poll();
+
+      if (!visited.contains(curr)) {
+        visited.add(curr);
+
+        if (isChild) {
           // Adds the children
-          for (GraphNode child : graph.successors(curr)) {
-            if (!visited.containsKey(child)) {
+          for (GraphNode child : this.graph().successors(curr)) {
+            if (!visited.contains(child)) {
               nextLayer.add(child);
             }
           }
+        } else {
           // Adds the parents
-          for (GraphNode parent : graph.predecessors(curr)) {
-            if (!visited.containsKey(parent)) {
+          for (GraphNode parent : graph().predecessors(curr)) {
+            if (!visited.contains(parent)) {
               nextLayer.add(parent);
             }
           }
         }
-      }
-      queue.addAll(nextLayer);
-    }
-    MutableGraph<GraphNode> graphToReturn = Graphs.inducedSubgraph(graph, visited.keySet());
 
-    return graphToReturn;
+      }
+    }
+    return nextLayer;
   }
 }

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -331,14 +331,14 @@ abstract class DataGraph {
   }
 
   /**
-   * Returns a MutableGraph with nodes that are at most a certain radius from a given node If the
-   * radius is less than 0 or the node specified isn't present, return an emptu graph Since maxDepth
+   * Returns a MutableGraph with nodes that are at most a certain radius from a given node. If the
+   * radius is less than 0 or the node specified isn't present, return an empty graph. Since maxDepth
    * was implemented as DFS, we use BFS for *diversity*
    *
    * @param name the name of the node to search for
    * @param radius the distance from the node to search for parents and children
    * @return a graph comprised of only nodes and edges within a certain distance from the specified
-   *     node
+   *     node. Empty if radius is less than 0 or if the node isn't found.
    */
   public MutableGraph<GraphNode> getReachableNodes(String name, int radius) {
     if (radius < 0) {

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -53,7 +53,7 @@ public class DataServlet extends HttpServlet {
 
     int depthNumber = Integer.parseInt(depthParam);
     int mutationNumber = Integer.parseInt(mutationParam);
-    System.out.println(mutationNumber);
+   
     boolean success = true; // Innocent until proven guilty; successful until proven a failure
 
     // Initialize variables if any are null. Ideally should all be null or none

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import java.io.IOException;
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 
@@ -100,7 +101,7 @@ public class DataServlet extends HttpServlet {
       // InputStreamReader(getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // MutationList.Builder mutBuilder = MutationList.newBuilder();
       // TextFormat.merge(mutReader, mutBuilder);
-      // List<Mutation> mutList = mutBuilder.build().getMutationList();
+      // mutList = mutBuilder.build().getMutationList();
       /*
        * This code is used to read a mutation list specified in proto binary format.
        */
@@ -112,7 +113,6 @@ public class DataServlet extends HttpServlet {
 
     // Parameter for the nodeName the user searched for in the frontend
     String nodeNameParam = request.getParameter("nodeName");
-    System.out.println(nodeNameParam);
 
     currDataGraph =
         Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
@@ -122,7 +122,8 @@ public class DataServlet extends HttpServlet {
       return;
     }
 
-    MutableGraph<GraphNode> truncatedGraph;
+    MutableGraph<GraphNode> truncatedGraph; // issue: has to get the truncated graph everytime
+    List<Mutation> truncatedMutList;
 
     // If a node is searched, get the graph with just the node. Otherwise, use the
     // whole graph

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -123,7 +123,6 @@ public class DataServlet extends HttpServlet {
     }
 
     MutableGraph<GraphNode> truncatedGraph; // issue: has to get the truncated graph everytime
-    List<Mutation> truncatedMutList;
 
     // If a node is searched, get the graph with just the node. Otherwise, use the
     // whole graph

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -122,7 +122,7 @@ public class DataServlet extends HttpServlet {
       return;
     }
 
-    MutableGraph<GraphNode> truncatedGraph; // issue: has to get the truncated graph everytime
+    MutableGraph<GraphNode> truncatedGraph;
 
     // If a node is searched, get the graph with just the node. Otherwise, use the
     // whole graph

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -112,6 +112,7 @@ public class DataServlet extends HttpServlet {
 
     // Parameter for the nodeName the user searched for in the frontend
     String nodeNameParam = request.getParameter("nodeName");
+    System.out.println(nodeNameParam);
 
     currDataGraph =
         Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
@@ -125,10 +126,10 @@ public class DataServlet extends HttpServlet {
 
     // If a node is searched, get the graph with just the node. Otherwise, use the
     // whole graph
-    if (nodeNameParam != null && !nodeNameParam.isEmpty()) {
-      truncatedGraph = currDataGraph.getReachableNodes(nodeNameParam, depthNumber);
+    if (nodeNameParam == null || nodeNameParam.length() == 0) {
+      truncatedGraph = currDataGraph.getGraphWithMaxDepth(depthNumber); 
     } else {
-      truncatedGraph = currDataGraph.getGraphWithMaxDepth(depthNumber);
+      truncatedGraph = currDataGraph.getReachableNodes(nodeNameParam, depthNumber);
     }
 
     String graphJson = Utility.graphToJson(truncatedGraph, mutList.size());

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -210,9 +210,12 @@ public class ReachableNodesTest {
     Assert.assertEquals(1, graphEdges.size());
   }
 
-  /** This test mirrors the example graph we have in graph.txt after the mutations specified. */
+  /**
+   * This test mirrors the example graph we have, tests that only parents of
+   * parents (and not children of parents) are added.
+   */
   @Test
-  public void complexGraph() {
+  public void linearNodesOnly() {
     nodeA.addChildren("B");
     nodeA.addChildren("C");
     nodeB.addChildren("D");
@@ -237,16 +240,16 @@ public class ReachableNodesTest {
     Set<GraphNode> graphNodes = truncatedGraph.nodes();
     Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
 
-    Assert.assertEquals(5, graphNodes.size());
+    Assert.assertEquals(4, graphNodes.size());
     Assert.assertTrue(graphNodes.contains(gNodeA));
     Assert.assertTrue(graphNodes.contains(gNodeB));
-    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertFalse(graphNodes.contains(gNodeC)); // Child of Parent, should not be in the graph
     Assert.assertTrue(graphNodes.contains(gNodeD));
     Assert.assertTrue(graphNodes.contains(gNodeG));
     Assert.assertFalse(graphNodes.contains(gNodeE));
     Assert.assertFalse(graphNodes.contains(gNodeH));
 
-    Assert.assertEquals(4, graphEdges.size());
+    Assert.assertEquals(3, graphEdges.size());
 
     // Test encapsulation, original graph isn't modified
     Assert.assertEquals(7, graph.nodes().size());

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -211,8 +211,8 @@ public class ReachableNodesTest {
   }
 
   /**
-   * This test mirrors the example graph we have, tests that only parents of
-   * parents (and not children of parents) are added.
+   * This test mirrors the example graph we have, tests that only parents of parents (and not
+   * children of parents) are added.
    */
   @Test
   public void linearNodesOnly() {

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -186,7 +186,7 @@ public class ReachableNodesTest {
   }
 
   /** Test nodes in a different connected component are not reachable */
-  @Test 
+  @Test
   public void diffConnectedComponentNotReachable() {
     nodeA.addChildren("B");
 
@@ -210,10 +210,7 @@ public class ReachableNodesTest {
     Assert.assertEquals(1, graphEdges.size());
   }
 
-  /**
-   * This test mirrors the example graph we have in graph.txt after the mutations
-   * specified.
-   */
+  /** This test mirrors the example graph we have in graph.txt after the mutations specified. */
   @Test
   public void complexGraph() {
     nodeA.addChildren("B");

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -185,6 +185,31 @@ public class ReachableNodesTest {
     Assert.assertEquals(2, graphEdges.size());
   }
 
+  /** Test nodes in a different connected component are not reachable */
+  @Test 
+  public void diffConnectedComponentNotReachable() {
+    nodeA.addChildren("B");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("B", 5);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(2, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertFalse(graphNodes.contains(gNodeC));
+
+    Assert.assertEquals(1, graphEdges.size());
+  }
+
   /**
    * This test mirrors the example graph we have in graph.txt after the mutations
    * specified.

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -1,0 +1,233 @@
+package com.google.sps;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import com.google.common.graph.EndpointPair;
+import com.google.common.graph.MutableGraph;
+import com.proto.GraphProtos.Node;
+import com.proto.GraphProtos.Node.Builder;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ReachableNodesTest {
+  // Proto nodes to construct graph with
+  Builder nodeA = Node.newBuilder().setName("A");
+  Builder nodeB = Node.newBuilder().setName("B");
+  Builder nodeC = Node.newBuilder().setName("C");
+  Builder nodeD = Node.newBuilder().setName("D");
+  Builder nodeE = Node.newBuilder().setName("E");
+  Builder nodeF = Node.newBuilder().setName("F");
+  Builder nodeG = Node.newBuilder().setName("G");
+  Builder nodeH = Node.newBuilder().setName("H");
+
+  GraphNode gNodeA;
+  GraphNode gNodeB;
+  GraphNode gNodeC;
+  GraphNode gNodeD;
+  GraphNode gNodeE;
+  GraphNode gNodeF;
+  GraphNode gNodeG;
+  GraphNode gNodeH;
+
+  @Before
+  public void setUp() {
+    gNodeA = Utility.protoNodeToGraphNode(nodeA.build());
+    gNodeB = Utility.protoNodeToGraphNode(nodeB.build());
+    gNodeC = Utility.protoNodeToGraphNode(nodeC.build());
+    gNodeD = Utility.protoNodeToGraphNode(nodeD.build());
+    gNodeE = Utility.protoNodeToGraphNode(nodeE.build());
+    gNodeF = Utility.protoNodeToGraphNode(nodeF.build());
+    gNodeG = Utility.protoNodeToGraphNode(nodeG.build());
+    gNodeH = Utility.protoNodeToGraphNode(nodeH.build());
+  }
+
+  /** Radius 0 should only return the node */
+  @Test
+  public void reachableNodesZero() {
+    nodeA.addChildren("B");
+    nodeA.addChildren("C");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("A", 0);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(1, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertFalse(graphNodes.contains(gNodeB));
+    Assert.assertFalse(graphNodes.contains(gNodeC));
+
+    Assert.assertEquals(0, graphEdges.size());
+  }
+
+  /** Children are considered in finding reachable nodes */
+  @Test
+  public void entireGraphReachableAsChildren() {
+    nodeA.addChildren("B");
+    nodeA.addChildren("C");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("A", 1);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(3, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+
+    Assert.assertEquals(2, graphEdges.size());
+  }
+
+  /** Parents are considered when finding reachable nodes */
+  @Test
+  public void parentsReachable() {
+    nodeA.addChildren("B");
+    nodeB.addChildren("C");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("C", 2);
+
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(3, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+
+    Assert.assertEquals(2, graphEdges.size());
+  }
+
+  /** Request only gets part of the graph, parent and children both included */
+  @Test
+  public void partOfGraphOnly() {
+    nodeA.addChildren("B");
+    nodeB.addChildren("C");
+    nodeC.addChildren("D");
+    nodeD.addChildren("E");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+    protoNodesMap.put("D", nodeD.build());
+    protoNodesMap.put("E", nodeE.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("C", 1);
+
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(3, graphNodes.size());
+    Assert.assertFalse(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertTrue(graphNodes.contains(gNodeD));
+    Assert.assertFalse(graphNodes.contains(gNodeE));
+   
+    Assert.assertEquals(2, graphEdges.size());
+  }
+
+  /** Radius is greater than the distance of any reachable node */
+  @Test
+  public void requestedGreaterThanMaxDepth() {
+    nodeA.addChildren("B");
+    nodeA.addChildren("C");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("A", 5);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(3, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+
+    Assert.assertEquals(2, graphEdges.size());
+  }
+
+  /**
+   * This test mirrors the example graph we have in graph.txt after the mutations
+   * specified.
+   */
+  @Test
+  public void complexGraph() {
+    nodeA.addChildren("B");
+    nodeA.addChildren("C");
+    nodeB.addChildren("D");
+    nodeD.addChildren("G");
+    nodeE.addChildren("G");
+    nodeH.addChildren("G");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+    protoNodesMap.put("D", nodeD.build());
+    protoNodesMap.put("E", nodeE.build());
+    protoNodesMap.put("G", nodeG.build());
+    protoNodesMap.put("H", nodeH.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+    MutableGraph<GraphNode> graph = dataGraph.graph();
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("B", 2);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(5, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA));
+    Assert.assertTrue(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC));
+    Assert.assertTrue(graphNodes.contains(gNodeD));
+    Assert.assertTrue(graphNodes.contains(gNodeG));
+    Assert.assertFalse(graphNodes.contains(gNodeE));
+    Assert.assertFalse(graphNodes.contains(gNodeH));
+
+    Assert.assertEquals(4, graphEdges.size());
+
+    // Test encapsulation, original graph isn't modified
+    Assert.assertEquals(7, graph.nodes().size());
+    Assert.assertEquals(6, graph.edges().size());
+  }
+}

--- a/src/main/java/com/google/sps/ReachableNodesTest.java
+++ b/src/main/java/com/google/sps/ReachableNodesTest.java
@@ -211,8 +211,8 @@ public class ReachableNodesTest {
   }
 
   /**
-   * This test mirrors the example graph we have, tests that only parents of parents (and not
-   * children of parents) are added.
+   * This test mirrors the example graph we have, tests that only parents of
+   * parents (and not children of parents) are added.
    */
   @Test
   public void linearNodesOnly() {
@@ -253,6 +253,48 @@ public class ReachableNodesTest {
 
     // Test encapsulation, original graph isn't modified
     Assert.assertEquals(7, graph.nodes().size());
+    Assert.assertEquals(6, graph.edges().size());
+  }
+
+  /** Test that with two ways to find a node, will find the shortest */
+  @Test
+  public void findsShorterPath() {
+    // A -> B -> D -> E -> F
+    // \> C ------------/> (C points to F)
+    nodeA.addChildren("B");
+    nodeA.addChildren("C");
+    nodeB.addChildren("D");
+    nodeD.addChildren("E");
+    nodeE.addChildren("F");
+    nodeC.addChildren("F");
+
+    HashMap<String, Node> protoNodesMap = new HashMap<>();
+    protoNodesMap.put("A", nodeA.build());
+    protoNodesMap.put("B", nodeB.build());
+    protoNodesMap.put("C", nodeC.build());
+    protoNodesMap.put("D", nodeD.build());
+    protoNodesMap.put("E", nodeE.build());
+    protoNodesMap.put("F", nodeF.build());
+
+    DataGraph dataGraph = DataGraph.create();
+    dataGraph.graphFromProtoNodes(protoNodesMap);
+    MutableGraph<GraphNode> graph = dataGraph.graph();
+
+    MutableGraph<GraphNode> truncatedGraph = dataGraph.getReachableNodes("F", 2);
+    Set<GraphNode> graphNodes = truncatedGraph.nodes();
+    Set<EndpointPair<GraphNode>> graphEdges = truncatedGraph.edges();
+
+    Assert.assertEquals(5, graphNodes.size());
+    Assert.assertTrue(graphNodes.contains(gNodeA)); // Found through C because it's the shorter path
+    Assert.assertFalse(graphNodes.contains(gNodeB));
+    Assert.assertTrue(graphNodes.contains(gNodeC)); 
+    Assert.assertTrue(graphNodes.contains(gNodeD));
+    Assert.assertTrue(graphNodes.contains(gNodeE));
+    Assert.assertTrue(graphNodes.contains(gNodeF));
+
+    Assert.assertEquals(4, graphEdges.size());
+
+    // Encapsulation
     Assert.assertEquals(6, graph.edges().size());
   }
 }

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -13,17 +13,22 @@
   <h1>
     Graph Visualization Tool
   </h1>
-  <label for="layers">Number of layers (0-20, default is 3):</label>
-  <input type="number" id="num-layers" name="layers"
-       min="0" max="20" value="3">
+  <div id="search-box">
+    <label for="layers">Number of layers (0-20, default is 3):</label>
+    <input type="number" id="num-layers" name="layers" min="0" max="20" value="3">
+    <label for="search-name">Name of node to search for</label>
+    <input type="text" id="node-name" name="search-name" placeholder="Name"></input>
+  </div>
   <button onclick="graph.generateGraph()">Get Graph</button>
-  <br/>
+  <br />
   <div id="graphdiv">
     <div id="graph"></div>
     <p id="buttontext">Navigate to the next and previous graph using the buttons below:</p>
     <div id="buttondiv">
-      <button id="prevbutton" class="nextprev material-icons" onclick="graph.navigateGraph(-1); graph.generateGraph()">navigate_before</button>
-      <button id="nextbutton" class="nextprev material-icons" onclick="graph.navigateGraph(1); graph.generateGraph()">navigate_next</button>
+      <button id="prevbutton" class="nextprev material-icons"
+        onclick="graph.navigateGraph(-1); graph.generateGraph()">navigate_before</button>
+      <button id="nextbutton" class="nextprev material-icons"
+        onclick="graph.navigateGraph(1); graph.generateGraph()">navigate_next</button>
     </div>
   </div>
 </body>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -26,11 +26,7 @@ import 'tippy.js/dist/tippy.css';
 import 'tippy.js/dist/backdrop.css';
 import 'tippy.js/animations/shift-away.css';
 
-<<<<<<< HEAD
-export { updateButtons, initializeNumMutations, setCurrGraphNum, initializeTippy, generateGraph, getUrl, navigateGraph, currGraphNum, numMutations };
-=======
 export { initializeNumMutations, setCurrGraphNum, initializeTippy, generateGraph, getUrl, navigateGraph, currGraphNum, numMutations, updateButtons };
->>>>>>> e1df1fa5b1163ca79ba14f78bd3217b1642f6b8f
 
 cytoscape.use(popper); // register extension
 cytoscape.use(dagre); // register extension

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -128,6 +128,7 @@ async function generateGraph() {
  */
 function getUrl() {
   const depthElem = document.getElementById('num-layers');
+  const nodeName = "placeholder"; // TODO: get the node name
   let selectedDepth = 0;
   if (depthElem === null) {
     selectedDepth = 3;
@@ -145,7 +146,7 @@ function getUrl() {
       selectedDepth = 20;
     }
   }
-  const url = `/data?depth=${selectedDepth}&mutationNum=${currGraphNum}`;
+  const url = `/data?depth=${selectedDepth}&mutationNum=${currGraphNum}&nodeName=${nodeName}`;
   return url;
 }
 /**

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -128,7 +128,7 @@ async function generateGraph() {
  */
 function getUrl() {
   const depthElem = document.getElementById('num-layers');
-  const nodeName = "placeholder"; // TODO: get the node name
+  const nodeName = document.getElementById('search-name') || null; // TODO: get the node name
   let selectedDepth = 0;
   if (depthElem === null) {
     selectedDepth = 3;
@@ -214,7 +214,7 @@ function getGraphDisplay(graphNodes, graphEdges) {
   cy.nodes().forEach(node => initializeTippy(node));
 
   // When the user clicks on a node, display the token list tooltip for the node
-  cy.on('tap', 'node', function(evt) {
+  cy.on('tap', 'node', function (evt) {
     const node = evt.target;
     node.tip.show();
   });
@@ -255,7 +255,7 @@ function getTooltipContent(node) {
   const closeButton = document.createElement("button");
   closeButton.innerText = "close";
   closeButton.classList.add("material-icons", "close-button");
-  closeButton.addEventListener('click', function() {
+  closeButton.addEventListener('click', function () {
     node.tip.hide();
   }, false);
   content.appendChild(closeButton);

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -83,7 +83,7 @@ async function generateGraph() {
   // Graph nodes and edges received from server
   const nodes = JSON.parse(jsonResponse.nodes);
   const edges = JSON.parse(jsonResponse.edges);
-  numMutations = JSON.parse(jsonResponse.numMutations);
+  initializeNumMutations(JSON.parse(jsonResponse.numMutations));
 
   if (!nodes || !edges || !Array.isArray(nodes) || !Array.isArray(edges)) {
     displayError("Malformed graph received from server - edges or nodes are empty");

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -128,7 +128,8 @@ async function generateGraph() {
  */
 function getUrl() {
   const depthElem = document.getElementById('num-layers');
-  const nodeName = document.getElementById('search-name') || null; // TODO: get the node name
+  const nodeName = document.getElementById('node-name').value || ""; 
+
   let selectedDepth = 0;
   if (depthElem === null) {
     selectedDepth = 3;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -45,7 +45,7 @@ function initializeNumMutations(num) {
   numMutations = num;
 }
 
-/**
+/** 
  * Sets the current graph number
  */
 function setCurrGraphNum(num) {
@@ -128,10 +128,10 @@ async function generateGraph() {
  */
 function getUrl() {
   const depthElem = document.getElementById('num-layers');
-  const nodeName = document.getElementById('node-name').value || ""; 
+  const nodeName = document.getElementById('node-name') ? document.getElementById('node-name').value || "" : ""; 
 
   let selectedDepth = 0;
-  if (depthElem === null) {
+  if (depthElem === null) {  
     selectedDepth = 3;
   }
   else {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -131,7 +131,7 @@ function getUrl() {
   const nodeName = document.getElementById('node-name') ? document.getElementById('node-name').value || "" : ""; 
 
   let selectedDepth = 0;
-  if (depthElem === null) {  
+  if (depthElem === null) {
     selectedDepth = 3;
   }
   else {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -52,3 +52,8 @@ body {
 .nextprev {
   margin: 20px;
 }
+
+#search-box {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
- Server side: create a function that takes in a string name and radius, outputs a new graph with only nodes (successors and parents of that node) within the specified radius of the given node. Add corresponding tests
- Client side: add a search box for node name, pass that to the server (also improve the style of the boxes a little!)

![Screenshot 2020-07-14 at 10 02 03 AM](https://user-images.githubusercontent.com/48307028/87442193-9a812d00-c5b9-11ea-92ae-40c37ed9349f.png)
![Screenshot 2020-07-14 at 10 01 25 AM](https://user-images.githubusercontent.com/48307028/87442196-9b19c380-c5b9-11ea-8459-f342104fc082.png)

Future optimizations:
- Right now the function of getting reachable nodes runs every time the search box changes. Possibly caching these graphs would prevent redundant work.
