### PR TITLE
Clicking next on a filtered/depth-limited graph goes to next graph where any displayed node is mutated

### DIFF
--- a/spec/jstests-spec.js
+++ b/spec/jstests-spec.js
@@ -205,7 +205,7 @@ describe("Pressing next and previous buttons associated with a graph", function 
   beforeEach(function () {
     numDisplay = document.createElement("div");
     numDisplay.id = "num-mutation-display";
-  });
+  }); 
 
   afterEach(function () {
     document.body.innerHTML = '';
@@ -312,6 +312,7 @@ describe("Pressing next and previous buttons associated with a graph", function 
     setCurrMutationIndex(.5);
     setCurrMutationNum(0);
     setMutationIndexList([0, 1, 3]);
+    initializeNumMutations(3);
     navigateGraph(1);
     expect(currMutationIndex).toBe(1);
     expect(currMutationNum).toBe(1);
@@ -322,6 +323,7 @@ describe("Pressing next and previous buttons associated with a graph", function 
     setCurrMutationIndex(.5);
     setCurrMutationNum(0);
     setMutationIndexList([0, 1, 3]);
+    initializeNumMutations(3);
     navigateGraph(-1);
     expect(currMutationIndex).toBe(0);
     expect(currMutationNum).toBe(0);
@@ -670,4 +672,4 @@ describe("Checking binary search functions", function () {
     expect(prevLower).toBe(-1);
     expect(nextHigher).toBe(0);
   });
-});
+}); 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -232,8 +232,8 @@ public class DataServlet extends HttpServlet {
         && diff.getMutationList().size() == 0) {
       response.setHeader(
           "serverMessage",
-          "The desired set of nodes is mutated in this graph but your other parameters (for"
-              + " eg. radius), limit the display of the mutations. Please try increasing your radius"
+          "The desired set of nodes is mutated in this graph but your other parameters (for eg."
+              + " radius), limit the display of the mutations. Please try increasing your radius"
               + " to view the mutation.");
     }
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -71,9 +71,12 @@ public class DataServlet extends HttpServlet {
      *********************************
      */
     if (currDataGraph == null && originalDataGraph == null) {
-      success = initializeGraphVariables(getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
+      success =
+          initializeGraphVariables(
+              getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
       if (!success) {
-        response.setHeader("serverError", "Failed to parse input graph into Guava graph - not a DAG!");
+        response.setHeader(
+            "serverError", "Failed to parse input graph into Guava graph - not a DAG!");
         return;
       }
       currDataGraph = originalDataGraph.getCopy();
@@ -88,7 +91,8 @@ public class DataServlet extends HttpServlet {
      *************************************
      */
     if (mutList == null) {
-      initializeMutationVariables(getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
+      initializeMutationVariables(
+          getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size()).boxed().collect(Collectors.toList());
       // and store this as the list of relevant indices for filtering by empty string
@@ -148,7 +152,9 @@ public class DataServlet extends HttpServlet {
 
     // Get the graph at the requested mutation number and truncate it
     try {
-      currDataGraph = Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
+      currDataGraph =
+          Utility.getGraphAtMutationNumber(
+              originalDataGraph, currDataGraph, mutationNumber, mutList);
     } catch (IllegalArgumentException e) {
       response.setHeader("serverError", e.getMessage());
       return;
@@ -165,7 +171,8 @@ public class DataServlet extends HttpServlet {
       if (nodeNameParam.length() != 0) {
         truncatedGraphNodeNames.add(nodeNameParam);
       }
-      filteredMutationIndices = Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
+      filteredMutationIndices =
+          Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
 
       // Filter the diff to only show mutations relevant to the above nodes
       diff = Utility.filterMultiMutationByNodes(diff, truncatedGraphNodeNames);
@@ -174,17 +181,20 @@ public class DataServlet extends HttpServlet {
     // We set the headers in the following 4 scenarios:
     // The searched node is not in the graph and is never mutated
     if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() == 0) {
-      response.setHeader("serverError", "The searched node does not exist anywhere in this graph or in mutations");
+      response.setHeader(
+          "serverError", "The searched node does not exist anywhere in this graph or in mutations");
       return;
     }
     // The searched node is not in the graph but is mutated at some past/future
     // point. The diff conditions are included to prevent entry into this case
     // when the searched node is deleted for example. The diff being non-empty
     // means that there is some mutation pertaining to the searched node to show
-    if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() != 0 &&
-        filteredMutationIndices.indexOf(mutationNumber) == -1 && 
-        (diff == null || diff.getMutationList().size() == 0)) {
-      response.setHeader("serverMessage",
+    if (truncatedGraph.nodes().size() == 0
+        && filteredMutationIndices.size() != 0
+        && filteredMutationIndices.indexOf(mutationNumber) == -1
+        && (diff == null || diff.getMutationList().size() == 0)) {
+      response.setHeader(
+          "serverMessage",
           "The searched node does not exist in this graph, so nothing is shown. However, it is"
               + " mutated at some other step. Please click next or previous to navigate to a graph"
               + " where this node exists.");
@@ -193,14 +203,18 @@ public class DataServlet extends HttpServlet {
     if (truncatedGraph.nodes().size() != 0
         && !(mutationNumber == -1 && nodeNameParam.equals(""))
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
-      response.setHeader("serverMessage",
+      response.setHeader(
+          "serverMessage",
           "The searched node exists in this graph! However, it is not mutated in this graph."
               + " Please click next or previous if you wish to see where it was mutated!");
     }
     // There is a diff between the previously-displayed graph and the current graph but
     // no mutations in it only mutate on-screen nodes
-    if (filteredMutationIndices.indexOf(mutationNumber) != -1 && diff != null && diff.getMutationList().size() == 0) {
-      response.setHeader("serverMessage",
+    if (filteredMutationIndices.indexOf(mutationNumber) != -1
+        && diff != null
+        && diff.getMutationList().size() == 0) {
+      response.setHeader(
+          "serverMessage",
           "The desired set of nodes is mutated in this graph but your other parameters (for"
               + " eg.depth), limit the display of the mutations. Please try increasing your radius"
               + " to view the mutation.");
@@ -211,12 +225,11 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intitialize graph variables. Returns a boolean to
-   * represent whether the InpuStream was read successfully.
+   * Private function to intitialize graph variables. Returns a boolean to represent whether the
+   * InpuStream was read successfully.
    *
    * @param graphInput InputStream to initialize graph variables over
-   * @return whether variables were initialized properly; true if successful and
-   *         false otherwise
+   * @return whether variables were initialized properly; true if successful and false otherwise
    * @throws IOException if something goes wrong during the reading
    */
   private boolean initializeGraphVariables(InputStream graphInput) throws IOException {

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -168,6 +168,7 @@ public class DataServlet extends HttpServlet {
       // Get the names of all the displayed nodes and find all indices of mutations
       // that mutate any of them
       Set<String> truncatedGraphNodeNames = Utility.getNodeNamesInGraph(truncatedGraph);
+      // Also get mutations relevant to the searched node if it is not an empty string
       if (nodeNameParam.length() != 0) {
         truncatedGraphNodeNames.add(nodeNameParam);
       }
@@ -191,8 +192,7 @@ public class DataServlet extends HttpServlet {
     // means that there is some mutation pertaining to the searched node to show
     if (truncatedGraph.nodes().size() == 0
         && filteredMutationIndices.size() != 0
-        && filteredMutationIndices.indexOf(mutationNumber) == -1
-        && (diff == null || diff.getMutationList().size() == 0)) {
+        && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       response.setHeader(
           "serverMessage",
           "The searched node does not exist in this graph, so nothing is shown. However, it is"

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -169,15 +169,15 @@ public class DataServlet extends HttpServlet {
     }
     truncatedGraph = currDataGraph.getReachableNodes(nodeNameParam, depthNumber);
     Set<String> truncatedGraphNodeNames = Utility.getNodeNamesInGraph(truncatedGraph);
-    if(nodeNameParam.length() != 0) {
+    if (nodeNameParam.length() != 0) {
       truncatedGraphNodeNames.add(nodeNameParam);
     }
 
-    filteredMutationIndices = Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
+    filteredMutationIndices =
+        Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
 
     // We filter the multimutation if there was a node searched
     diff = Utility.filterMultiMutationByNodes(diff, truncatedGraphNodeNames);
-
 
     // We set the headers in the following 3 scenarios:
     // The searched node is not in the graph and is never mutated
@@ -204,14 +204,13 @@ public class DataServlet extends HttpServlet {
           "The searched node exists in this graph! However, it is not mutated in this graph."
               + " Please click next or previous if you wish to see where it was mutated!");
     }
-    if(diff != null && diff.getMutationList().size() == 0) {
+    if (diff != null && diff.getMutationList().size() == 0) {
       response.setHeader(
           "serverMessage",
-          "The desired set of nodes is mutated in this graph but your other parameters (for eg."
-             + "depth), limit the display of the mutations. Please try increasing your radius to view"
-             + "the mutation.");
+          "The desired set of nodes is mutated in this graph but your other parameters (for"
+              + " eg.depth), limit the display of the mutations. Please try increasing your radius"
+              + " to viewthe mutation.");
     }
-
 
     graphJson = Utility.graphToJson(truncatedGraph, filteredMutationIndices, diff, mutList.size());
     response.getWriter().println(graphJson);

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -73,7 +73,7 @@ public class DataServlet extends HttpServlet {
     if (currDataGraph == null && originalDataGraph == null) {
       success =
           initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
+              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       if (!success) {
         response.setHeader(
             "serverError", "Failed to parse input graph into Guava graph - not a DAG!");
@@ -92,7 +92,7 @@ public class DataServlet extends HttpServlet {
      */
     if (mutList == null) {
       initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
+          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size()).boxed().collect(Collectors.toList());
       // and store this as the list of relevant indices for filtering by empty string
@@ -161,7 +161,7 @@ public class DataServlet extends HttpServlet {
     }
     truncatedGraph = currDataGraph.getReachableNodes(nodeNameParam, depthNumber);
 
-    if (nodeNameParam.equals("") && truncatedGraph.equals(currDataGraph.graph())) {
+    if (nodeNameParam.length() == 0 && truncatedGraph.equals(currDataGraph.graph())) {
       // If we are not filtering the graph or limiting its depth, show all mutations of all nodes
       filteredMutationIndices = defaultIndices;
     } else {
@@ -192,7 +192,8 @@ public class DataServlet extends HttpServlet {
     // means that there is some mutation pertaining to the searched node to show
     if (truncatedGraph.nodes().size() == 0
         && filteredMutationIndices.size() != 0
-        && filteredMutationIndices.indexOf(mutationNumber) == -1) {
+        && filteredMutationIndices.indexOf(mutationNumber) == -1
+        && (diff == null || diff.getMutationList().size() == 0)) {
       response.setHeader(
           "serverMessage",
           "The searched node does not exist in this graph, so nothing is shown. However, it is"
@@ -201,7 +202,7 @@ public class DataServlet extends HttpServlet {
     }
     // The searched node exists but is not mutated in the current graph
     if (truncatedGraph.nodes().size() != 0
-        && !(mutationNumber == -1 && nodeNameParam.equals(""))
+        && !(mutationNumber == -1 && nodeNameParam.length() == 0)
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       response.setHeader(
           "serverMessage",

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -168,10 +168,12 @@ public class DataServlet extends HttpServlet {
       // Get the names of all the displayed nodes and find all indices of mutations
       // that mutate any of them
       Set<String> truncatedGraphNodeNames = Utility.getNodeNamesInGraph(truncatedGraph);
+
       // Also get mutations relevant to the searched node if it is not an empty string
       if (nodeNameParam.length() != 0) {
         truncatedGraphNodeNames.add(nodeNameParam);
       }
+
       filteredMutationIndices =
           Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
 
@@ -217,10 +219,9 @@ public class DataServlet extends HttpServlet {
       response.setHeader(
           "serverMessage",
           "The desired set of nodes is mutated in this graph but your other parameters (for"
-              + " eg.depth), limit the display of the mutations. Please try increasing your radius"
+              + " eg. radius), limit the display of the mutations. Please try increasing your radius"
               + " to view the mutation.");
     }
-
     graphJson = Utility.graphToJson(truncatedGraph, filteredMutationIndices, diff, mutList.size());
     response.getWriter().println(graphJson);
   }

--- a/src/main/java/com/google/sps/MutationDiffTest.java
+++ b/src/main/java/com/google/sps/MutationDiffTest.java
@@ -518,5 +518,6 @@ public class MutationDiffTest {
     List<Mutation> filteredMutList = filteredMultiMut.getMutationList();
     Assert.assertEquals(filteredMutList.size(), 2);
     Assert.assertEquals(filteredMutList.get(0), addTokenToB);
+    Assert.assertEquals(filteredMutList.get(1), removeB);
   }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -30,9 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test for functions within Utility that are used to filter graphs across nodes
- */
+/** Test for functions within Utility that are used to filter graphs across nodes */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
   // lst1 contains even number of elements
@@ -41,15 +39,23 @@ public class NodeMutationFilterTest {
   List<Integer> lst2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
 
   // Following functions test the getMutationIndicesOfNode function in Utility
-  /**
-   * Basic test for including mutliple relevant nodes for getMutationIndicesOfNode
-   */
+  /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
   @Test
   public void getMutationsOfBasic() {
-    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
-    Mutation removeAB = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").setEndNode("B")
-        .build();
-    Mutation removeC = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
+    Mutation removeAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
+    Mutation removeC =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
@@ -69,7 +75,12 @@ public class NodeMutationFilterTest {
   /** Test that a null query returns an empty list */
   @Test
   public void getMutationsOfNull() {
-    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     List<MultiMutation> multiMutList = new ArrayList<>();
@@ -82,28 +93,56 @@ public class NodeMutationFilterTest {
     Assert.assertFalse(truncatedList.contains(0));
   }
 
-  /**
-   * Returns a standard list of multimutations that is used for testing various functions
-   */
+  /** Returns a standard list of multimutations that is used for testing various functions */
   private List<MultiMutation> getTestMutationList() {
-    Mutation removeEF = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("E").setEndNode("F")
-        .build();
-    Mutation removeF = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+    Mutation removeEF =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("E")
+            .setEndNode("F")
+            .build();
+    Mutation removeF =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
 
     Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-    Mutation addEG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("E").setEndNode("G").build();
+    Mutation addEG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("E")
+            .setEndNode("G")
+            .build();
 
     Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-    Mutation addHG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("H").setEndNode("G").build();
+    Mutation addHG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("H")
+            .setEndNode("G")
+            .build();
 
-    Mutation addDG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("D").setEndNode("G").build();
+    Mutation addDG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("D")
+            .setEndNode("G")
+            .build();
 
-    TokenMutation tokenMut = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("1")
-        .addTokenName("2").addTokenName("3").build();
-    Mutation addTokenToB = Mutation.newBuilder().setStartNode("B").setType(Mutation.Type.CHANGE_TOKEN)
-        .setTokenChange(tokenMut).build();
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    Mutation addTokenToB =
+        Mutation.newBuilder()
+            .setStartNode("B")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
-    MultiMutation removeFM = MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation removeFM =
+        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
     MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
     MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
     MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
@@ -119,20 +158,21 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of multiple nodes returns the union of all their
-   * individual indices in sorted order
+   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
+   * sorted order
    */
   @Test
   public void getMutationsOfMultiple() {
     List<MultiMutation> multiMutList = getTestMutationList();
-    
+
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
     nodeNames.add("A");
     nodeNames.add("B");
     nodeNames.add("D");
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(2, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 3);
@@ -140,8 +180,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of multiple nodes returns the union of all their
-   * individual indices in sorted order without duplicates
+   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
+   * sorted order without duplicates
    */
   @Test
   public void getMutationsOfMultipleNoDuplicates() {
@@ -152,7 +192,8 @@ public class NodeMutationFilterTest {
     nodeNames.add("G");
     nodeNames.add("E");
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 0);
@@ -161,10 +202,7 @@ public class NodeMutationFilterTest {
     Assert.assertTrue(truncatedList.get(3) == 3);
   }
 
-  /**
-   * Getting mutation indices of nodes not present in any mutations returns an
-   * empty list
-   */
+  /** Getting mutation indices of nodes not present in any mutations returns an empty list */
   @Test
   public void getMutationsOfAbsentNodes() {
     List<MultiMutation> multiMutList = getTestMutationList();
@@ -174,14 +212,14 @@ public class NodeMutationFilterTest {
     nodeNames.add("P");
     nodeNames.add("Q");
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(0, truncatedList.size());
   }
 
   /**
-   * Getting mutation indices of nodes where some don't exist just ignores the
-   * non-existent nodes
+   * Getting mutation indices of nodes where some don't exist just ignores the non-existent nodes
    */
   @Test
   public void getMutationsOfSomeAbsent() {
@@ -193,7 +231,8 @@ public class NodeMutationFilterTest {
     nodeNames.add("E");
     nodeNames.add("L");
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 0);
@@ -203,8 +242,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of nodes with an empty list of multimutations just
-   * returns a list of size 0
+   * Getting mutation indices of nodes with an empty list of multimutations just returns a list of
+   * size 0
    */
   @Test
   public void getMutationsOfMultipleEmptyMutations() {
@@ -215,14 +254,13 @@ public class NodeMutationFilterTest {
     nodeNames.add("G");
     nodeNames.add("E");
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(0, truncatedList.size());
   }
 
-  /**
-   * Getting mutation indices of an empty list of nodes just returns all indices
-   */
+  /** Getting mutation indices of an empty list of nodes just returns all indices */
   @Test
   public void getMutationsOfEmpty() {
     List<MultiMutation> multiMutList = getTestMutationList();
@@ -230,7 +268,8 @@ public class NodeMutationFilterTest {
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
 
-    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(5, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 0);

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -255,11 +255,87 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
-   * sorted order without duplicates, ignoring empty strings
+   * Getting mutation indices of nodes not present in any mutations returns an empty list
    */
   @Test
-  public void getMutationsOfMultipleIgnoreEmpty() {
+  public void getMutationsOfAbsentNodes() {
+    Mutation removeEF =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("E")
+            .setEndNode("F")
+            .build();
+    Mutation removeF =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+
+    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
+    Mutation addEG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("E")
+            .setEndNode("G")
+            .build();
+
+    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
+    Mutation addHG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("H")
+            .setEndNode("G")
+            .build();
+
+    Mutation addDG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("D")
+            .setEndNode("G")
+            .build();
+
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    Mutation addTokenToB =
+        Mutation.newBuilder()
+            .setStartNode("B")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
+
+    MultiMutation removeFM =
+        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
+    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
+    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
+    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
+
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(removeFM);
+    multiMutList.add(addGM);
+    multiMutList.add(addHM);
+    multiMutList.add(addDGM);
+    multiMutList.add(addTokenToBM);
+
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+    nodeNames.add("P");
+    nodeNames.add("Q");
+
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+
+    Assert.assertEquals(0, truncatedList.size());
+  }
+
+  /**
+   * Getting mutation indices of nodes where some don't exist just ignores the 
+   * non-existent nodes
+   */
+  @Test
+  public void getMutationsOfSomeAbsent() {
     Mutation removeEF =
         Mutation.newBuilder()
             .setType(Mutation.Type.DELETE_EDGE)
@@ -324,7 +400,7 @@ public class NodeMutationFilterTest {
     Set<String> nodeNames = new HashSet<>();
     nodeNames.add("G");
     nodeNames.add("E");
-    nodeNames.add("");
+    nodeNames.add("L");
 
     List<Integer> truncatedList =
         Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
@@ -334,5 +410,24 @@ public class NodeMutationFilterTest {
     Assert.assertTrue(truncatedList.get(1) == 1);
     Assert.assertTrue(truncatedList.get(2) == 2);
     Assert.assertTrue(truncatedList.get(3) == 3);
+  }
+
+  /**
+   * Getting mutation indices of nodes with an empty list of multimutations 
+   * just returns a list of size 0
+   */
+  @Test
+  public void getMutationsOfMultipleIgnoreEmpty() {
+    List<MultiMutation> multiMutList = new ArrayList<>();
+
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+    nodeNames.add("G");
+    nodeNames.add("E");
+
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+
+    Assert.assertEquals(0, truncatedList.size());
   }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test for functions within Utility that are used to filter graphs across nodes */
+/**
+ * Test for functions within Utility that are used to filter graphs across nodes
+ */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
   // lst1 contains even number of elements
@@ -39,23 +41,15 @@ public class NodeMutationFilterTest {
   List<Integer> lst2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
 
   // Following functions test the getMutationIndicesOfNode function in Utility
-  /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
+  /**
+   * Basic test for including mutliple relevant nodes for getMutationIndicesOfNode
+   */
   @Test
   public void getMutationsOfBasic() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeC =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
+    Mutation removeAB = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").setEndNode("B")
+        .build();
+    Mutation removeC = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
@@ -75,12 +69,7 @@ public class NodeMutationFilterTest {
   /** Test that a null query returns an empty list */
   @Test
   public void getMutationsOfNull() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     List<MultiMutation> multiMutList = new ArrayList<>();
@@ -94,59 +83,27 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
-   * sorted order
+   * Returns a standard list of multimutations that is used for testing various functions
    */
-  @Test
-  public void getMutationsOfMultiple() {
-    Mutation removeEF =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("E")
-            .setEndNode("F")
-            .build();
-    Mutation removeF =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+  private List<MultiMutation> getTestMutationList() {
+    Mutation removeEF = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("E").setEndNode("F")
+        .build();
+    Mutation removeF = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
 
     Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-    Mutation addEG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("E")
-            .setEndNode("G")
-            .build();
+    Mutation addEG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("E").setEndNode("G").build();
 
     Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-    Mutation addHG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("H")
-            .setEndNode("G")
-            .build();
+    Mutation addHG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("H").setEndNode("G").build();
 
-    Mutation addDG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("D")
-            .setEndNode("G")
-            .build();
+    Mutation addDG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("D").setEndNode("G").build();
 
-    TokenMutation tokenMut =
-        TokenMutation.newBuilder()
-            .setType(TokenMutation.Type.ADD_TOKEN)
-            .addTokenName("1")
-            .addTokenName("2")
-            .addTokenName("3")
-            .build();
-    Mutation addTokenToB =
-        Mutation.newBuilder()
-            .setStartNode("B")
-            .setType(Mutation.Type.CHANGE_TOKEN)
-            .setTokenChange(tokenMut)
-            .build();
+    TokenMutation tokenMut = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("1")
+        .addTokenName("2").addTokenName("3").build();
+    Mutation addTokenToB = Mutation.newBuilder().setStartNode("B").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut).build();
 
-    MultiMutation removeFM =
-        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation removeFM = MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
     MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
     MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
     MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
@@ -158,15 +115,24 @@ public class NodeMutationFilterTest {
     multiMutList.add(addHM);
     multiMutList.add(addDGM);
     multiMutList.add(addTokenToBM);
+    return multiMutList;
+  }
 
+  /**
+   * Getting mutation indices of multiple nodes returns the union of all their
+   * individual indices in sorted order
+   */
+  @Test
+  public void getMutationsOfMultiple() {
+    List<MultiMutation> multiMutList = getTestMutationList();
+    
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
     nodeNames.add("A");
     nodeNames.add("B");
     nodeNames.add("D");
 
-    List<Integer> truncatedList =
-        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(2, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 3);
@@ -174,78 +140,19 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
-   * sorted order without duplicates
+   * Getting mutation indices of multiple nodes returns the union of all their
+   * individual indices in sorted order without duplicates
    */
   @Test
   public void getMutationsOfMultipleNoDuplicates() {
-    Mutation removeEF =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("E")
-            .setEndNode("F")
-            .build();
-    Mutation removeF =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
-
-    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-    Mutation addEG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("E")
-            .setEndNode("G")
-            .build();
-
-    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-    Mutation addHG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("H")
-            .setEndNode("G")
-            .build();
-
-    Mutation addDG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("D")
-            .setEndNode("G")
-            .build();
-
-    TokenMutation tokenMut =
-        TokenMutation.newBuilder()
-            .setType(TokenMutation.Type.ADD_TOKEN)
-            .addTokenName("1")
-            .addTokenName("2")
-            .addTokenName("3")
-            .build();
-    Mutation addTokenToB =
-        Mutation.newBuilder()
-            .setStartNode("B")
-            .setType(Mutation.Type.CHANGE_TOKEN)
-            .setTokenChange(tokenMut)
-            .build();
-
-    MultiMutation removeFM =
-        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
-
-    List<MultiMutation> multiMutList = new ArrayList<>();
-    multiMutList.add(removeFM);
-    multiMutList.add(addGM);
-    multiMutList.add(addHM);
-    multiMutList.add(addDGM);
-    multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = getTestMutationList();
 
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
     nodeNames.add("G");
     nodeNames.add("E");
 
-    List<Integer> truncatedList =
-        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 0);
@@ -254,144 +161,31 @@ public class NodeMutationFilterTest {
     Assert.assertTrue(truncatedList.get(3) == 3);
   }
 
-  /** Getting mutation indices of nodes not present in any mutations returns an empty list */
+  /**
+   * Getting mutation indices of nodes not present in any mutations returns an
+   * empty list
+   */
   @Test
   public void getMutationsOfAbsentNodes() {
-    Mutation removeEF =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("E")
-            .setEndNode("F")
-            .build();
-    Mutation removeF =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
-
-    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-    Mutation addEG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("E")
-            .setEndNode("G")
-            .build();
-
-    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-    Mutation addHG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("H")
-            .setEndNode("G")
-            .build();
-
-    Mutation addDG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("D")
-            .setEndNode("G")
-            .build();
-
-    TokenMutation tokenMut =
-        TokenMutation.newBuilder()
-            .setType(TokenMutation.Type.ADD_TOKEN)
-            .addTokenName("1")
-            .addTokenName("2")
-            .addTokenName("3")
-            .build();
-    Mutation addTokenToB =
-        Mutation.newBuilder()
-            .setStartNode("B")
-            .setType(Mutation.Type.CHANGE_TOKEN)
-            .setTokenChange(tokenMut)
-            .build();
-
-    MultiMutation removeFM =
-        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
-
-    List<MultiMutation> multiMutList = new ArrayList<>();
-    multiMutList.add(removeFM);
-    multiMutList.add(addGM);
-    multiMutList.add(addHM);
-    multiMutList.add(addDGM);
-    multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = getTestMutationList();
 
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
     nodeNames.add("P");
     nodeNames.add("Q");
 
-    List<Integer> truncatedList =
-        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(0, truncatedList.size());
   }
 
   /**
-   * Getting mutation indices of nodes where some don't exist just ignores the non-existent nodes
+   * Getting mutation indices of nodes where some don't exist just ignores the
+   * non-existent nodes
    */
   @Test
   public void getMutationsOfSomeAbsent() {
-    Mutation removeEF =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("E")
-            .setEndNode("F")
-            .build();
-    Mutation removeF =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
-
-    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-    Mutation addEG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("E")
-            .setEndNode("G")
-            .build();
-
-    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-    Mutation addHG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("H")
-            .setEndNode("G")
-            .build();
-
-    Mutation addDG =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("D")
-            .setEndNode("G")
-            .build();
-
-    TokenMutation tokenMut =
-        TokenMutation.newBuilder()
-            .setType(TokenMutation.Type.ADD_TOKEN)
-            .addTokenName("1")
-            .addTokenName("2")
-            .addTokenName("3")
-            .build();
-    Mutation addTokenToB =
-        Mutation.newBuilder()
-            .setStartNode("B")
-            .setType(Mutation.Type.CHANGE_TOKEN)
-            .setTokenChange(tokenMut)
-            .build();
-
-    MultiMutation removeFM =
-        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
-
-    List<MultiMutation> multiMutList = new ArrayList<>();
-    multiMutList.add(removeFM);
-    multiMutList.add(addGM);
-    multiMutList.add(addHM);
-    multiMutList.add(addDGM);
-    multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = getTestMutationList();
 
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
     Set<String> nodeNames = new HashSet<>();
@@ -399,8 +193,7 @@ public class NodeMutationFilterTest {
     nodeNames.add("E");
     nodeNames.add("L");
 
-    List<Integer> truncatedList =
-        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
     Assert.assertTrue(truncatedList.get(0) == 0);
@@ -410,11 +203,11 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of nodes with an empty list of multimutations just returns a list of
-   * size 0
+   * Getting mutation indices of nodes with an empty list of multimutations just
+   * returns a list of size 0
    */
   @Test
-  public void getMutationsOfMultipleIgnoreEmpty() {
+  public void getMutationsOfMultipleEmptyMutations() {
     List<MultiMutation> multiMutList = new ArrayList<>();
 
     HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
@@ -422,9 +215,28 @@ public class NodeMutationFilterTest {
     nodeNames.add("G");
     nodeNames.add("E");
 
-    List<Integer> truncatedList =
-        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(0, truncatedList.size());
+  }
+
+  /**
+   * Getting mutation indices of an empty list of nodes just returns all indices
+   */
+  @Test
+  public void getMutationsOfEmpty() {
+    List<MultiMutation> multiMutList = getTestMutationList();
+
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+
+    List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+
+    Assert.assertEquals(5, truncatedList.size());
+    Assert.assertTrue(truncatedList.get(0) == 0);
+    Assert.assertTrue(truncatedList.get(1) == 1);
+    Assert.assertTrue(truncatedList.get(2) == 2);
+    Assert.assertTrue(truncatedList.get(3) == 3);
+    Assert.assertTrue(truncatedList.get(4) == 4);
   }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -254,9 +254,7 @@ public class NodeMutationFilterTest {
     Assert.assertTrue(truncatedList.get(3) == 3);
   }
 
-  /**
-   * Getting mutation indices of nodes not present in any mutations returns an empty list
-   */
+  /** Getting mutation indices of nodes not present in any mutations returns an empty list */
   @Test
   public void getMutationsOfAbsentNodes() {
     Mutation removeEF =
@@ -331,8 +329,7 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of nodes where some don't exist just ignores the 
-   * non-existent nodes
+   * Getting mutation indices of nodes where some don't exist just ignores the non-existent nodes
    */
   @Test
   public void getMutationsOfSomeAbsent() {
@@ -413,8 +410,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * Getting mutation indices of nodes with an empty list of multimutations 
-   * just returns a list of size 0
+   * Getting mutation indices of nodes with an empty list of multimutations just returns a list of
+   * size 0
    */
   @Test
   public void getMutationsOfMultipleIgnoreEmpty() {

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.stream.IntStream;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -252,6 +253,9 @@ public final class Utility {
       Set<String> nodeNames,
       Map<String, List<Integer>> mutationIndicesMap,
       List<MultiMutation> multiMutList) {
+    if(nodeNames.size() == 0) {
+      return IntStream.range(0, multiMutList.size()).boxed().collect(Collectors.toList());
+    }
     Set<Integer> relevantIndices = new HashSet<>();
     for (String nodeName : nodeNames) {
       // Find or compute and cache the relevant mutation indices for each node

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -263,7 +263,7 @@ public final class Utility {
       Set<String> nodeNames,
       Map<String, List<Integer>> mutationIndicesMap,
       List<MultiMutation> multiMutList) {
-    if(nodeNames.size() == 0) {
+    if (nodeNames.size() == 0) {
       return IntStream.range(0, multiMutList.size()).boxed().collect(Collectors.toList());
     }
     Set<Integer> relevantIndices = new HashSet<>();

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -254,10 +254,6 @@ public final class Utility {
       List<MultiMutation> multiMutList) {
     Set<Integer> relevantIndices = new HashSet<>();
     for (String nodeName : nodeNames) {
-      // No node name should be an empty string
-      if (nodeName.equals("")) {
-        continue;
-      }
       // Find or compute and cache the relevant mutation indices for each node
       if (!mutationIndicesMap.containsKey(nodeName)) {
         mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -16,8 +16,11 @@ package com.google.sps;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -229,5 +232,19 @@ public final class Utility {
         .addAllMutation(filteredMutationList)
         .setReason(mm.getReason())
         .build();
+  }
+
+  public static List<Integer> findRelevantMutations(Set<String> nodeNames, Map<String, List<Integer>> mutationIndicesMap, List<MultiMutation> multiMutList) {
+    Set<Integer> relevantIndices = new HashSet<>();
+    for(String nodeName : nodeNames) {
+      if (!mutationIndicesMap.containsKey(nodeName)) {
+        mutationIndicesMap.put(
+            nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
+      }
+      relevantIndices.addAll(mutationIndicesMap.get(nodeName));
+    }
+    ArrayList<Integer> result = new ArrayList<>(relevantIndices);
+    Collections.sort(result);
+    return result;
   }
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -234,12 +234,14 @@ public final class Utility {
         .build();
   }
 
-  public static List<Integer> findRelevantMutations(Set<String> nodeNames, Map<String, List<Integer>> mutationIndicesMap, List<MultiMutation> multiMutList) {
+  public static List<Integer> findRelevantMutations(
+      Set<String> nodeNames,
+      Map<String, List<Integer>> mutationIndicesMap,
+      List<MultiMutation> multiMutList) {
     Set<Integer> relevantIndices = new HashSet<>();
-    for(String nodeName : nodeNames) {
+    for (String nodeName : nodeNames) {
       if (!mutationIndicesMap.containsKey(nodeName)) {
-        mutationIndicesMap.put(
-            nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
+        mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
       }
       relevantIndices.addAll(mutationIndicesMap.get(nodeName));
     }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -42,8 +42,8 @@ public final class Utility {
   }
 
   /**
-   * Converts a proto node object into a graph node object that does not store the names of the
-   * child nodes but may store additional information.
+   * Converts a proto node object into a graph node object that does not store the
+   * names of the child nodes but may store additional information.
    *
    * @param thisNode the input data Node object
    * @return a useful node used to construct the Guava Graph
@@ -56,61 +56,55 @@ public final class Utility {
   }
 
   /**
-   * Converts a Guava graph into a String encoding of a JSON Object. The object contains nodes and
-   * edges of the graph.
+   * Converts a Guava graph into a String encoding of a JSON Object. The object
+   * contains nodes and edges of the graph.
    *
-   * @param graph the graph to convert into a JSON String
+   * @param graph           the graph to convert into a JSON String
    * @param mutationIndices the list of indices of relevant mutations
-   * @param mutDiff the difference between the current graph and the requested graph
-   * @param maxNumber the total number of mutations, without filtering
-   * @return a JSON object containing as entries the nodes and edges of this graph as well as the
-   *     length of the list of mutations this graph is an intermediate result of applying
+   * @param mutDiff         the difference between the current graph and the
+   *                        requested graph
+   * @param maxNumber       the total number of mutations, without filtering
+   * @return a JSON object containing as entries the nodes and edges of this graph
+   *         as well as the length of the list of mutations this graph is an
+   *         intermediate result of applying
    */
-  public static String graphToJson(
-      MutableGraph<GraphNode> graph,
-      List<Integer> mutationIndices,
-      MultiMutation mutDiff,
+  public static String graphToJson(MutableGraph<GraphNode> graph, List<Integer> mutationIndices, MultiMutation mutDiff,
       int maxNumber) {
-    Type typeOfNode = new TypeToken<Set<GraphNode>>() {}.getType();
-    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {}.getType();
-    Type typeOfIndices = new TypeToken<List<Integer>>() {}.getType();
+    Type typeOfNode = new TypeToken<Set<GraphNode>>() {
+    }.getType();
+    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {
+    }.getType();
+    Type typeOfIndices = new TypeToken<List<Integer>>() {
+    }.getType();
     Gson gson = new Gson();
     String nodeJson = gson.toJson(graph.nodes(), typeOfNode);
     String edgeJson = gson.toJson(graph.edges(), typeOfEdge);
-    String mutDiffJson =
-        (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
+    String mutDiffJson = (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
     String reason = (mutDiff == null || !mutDiff.isInitialized()) ? "" : mutDiff.getReason();
     String mutationIndicesJson = gson.toJson(mutationIndices, typeOfIndices);
-    String resultJson =
-        new JSONObject()
-            .put("nodes", nodeJson)
-            .put("edges", edgeJson)
-            .put("mutationDiff", mutDiffJson)
-            .put("reason", reason)
-            .put("mutationIndices", mutationIndicesJson)
-            .put("totalMutNumber", maxNumber)
-            .toString();
+    String resultJson = new JSONObject().put("nodes", nodeJson).put("edges", edgeJson).put("mutationDiff", mutDiffJson)
+        .put("reason", reason).put("mutationIndices", mutationIndicesJson).put("totalMutNumber", maxNumber).toString();
     return resultJson;
   }
 
   /**
-   * Returns the graph at the given mutation number null if the requested number is less than -1. If
-   * the user requests a number greater than the total number of mutations, we return the final
-   * graph.
+   * Returns the graph at the given mutation number null if the requested number
+   * is less than -1. If the user requests a number greater than the total number
+   * of mutations, we return the final graph.
    *
-   * @param original the original graph
-   * @param curr the current (most recently-requested) graph (requires that original != curr)
-   * @param mutationNum number of mutations to apply
+   * @param original     the original graph
+   * @param curr         the current (most recently-requested) graph (requires
+   *                     that original != curr)
+   * @param mutationNum  number of mutations to apply
    * @param multiMutList multi-mutation list
-   * @throws IllegalArgumentException if original and current graph refer to the same object
-   * @return the resulting data graph, null if the mutation number was too small, and the final
-   *     graph if the mutation number was too big
+   * @throws IllegalArgumentException if original and current graph refer to the
+   *                                  same object
+   * @return the resulting data graph, null if the mutation number was too small,
+   *         and the final graph if the mutation number was too big
    */
-  public static DataGraph getGraphAtMutationNumber(
-      DataGraph original, DataGraph curr, int mutationNum, List<MultiMutation> multiMutList)
-      throws IllegalArgumentException {
-    Preconditions.checkArgument(
-        original != curr, "The current graph and the original graph refer to the same object");
+  public static DataGraph getGraphAtMutationNumber(DataGraph original, DataGraph curr, int mutationNum,
+      List<MultiMutation> multiMutList) throws IllegalArgumentException {
+    Preconditions.checkArgument(original != curr, "The current graph and the original graph refer to the same object");
 
     if (mutationNum < -1) {
       return null;
@@ -144,19 +138,22 @@ public final class Utility {
           }
         }
       }
-      return DataGraph.create(
-          originalCopy.graph(), originalCopy.graphNodesMap(), originalCopy.roots(), mutationNum);
+      return DataGraph.create(originalCopy.graph(), originalCopy.graphNodesMap(), originalCopy.roots(), mutationNum);
     }
   }
 
   /**
-   * Returns a multi-mutation (list of mutations) that need to be applied to get from the graph at
-   * currIndex to the graph at nextIndex as long as nextIndex = currIndex + 1
+   * Returns a multi-mutation (list of mutations) that need to be applied to get
+   * from the graph at currIndex to the graph at nextIndex as long as nextIndex =
+   * currIndex + 1
    *
-   * @param multiMutList the list of multi-mutations that are to be applied to the initial graph
-   * @param index the index in the above list at which the multimutation to apply is
-   * @return a multimutation with all the changes to apply to the current graph to get the next
-   *     graph or null if the provided indices are out of bounds or non-consecutive
+   * @param multiMutList the list of multi-mutations that are to be applied to the
+   *                     initial graph
+   * @param index        the index in the above list at which the multimutation to
+   *                     apply is
+   * @return a multimutation with all the changes to apply to the current graph to
+   *         get the next graph or null if the provided indices are out of bounds
+   *         or non-consecutive
    */
   public static MultiMutation getMultiMutationAtIndex(List<MultiMutation> multiMutList, int index) {
     if (index < 0 || index >= multiMutList.size()) {
@@ -166,14 +163,14 @@ public final class Utility {
   }
 
   /**
-   * Returns a list of the indices of the mutations in origList that mutate nodeName
+   * Returns a list of the indices of the mutations in origList that mutate
+   * nodeName
    *
    * @param nodeName the name of the node to filter
    * @param origList the original list of mutations
    * @return a list of indices that are relevant to the node
    */
-  public static ArrayList<Integer> getMutationIndicesOfNode(
-      String nodeName, List<MultiMutation> origList) {
+  public static ArrayList<Integer> getMutationIndicesOfNode(String nodeName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
     // Shouldn't happen, but in case the nodeName is null an empty list is returned
     if (nodeName == null) {
@@ -195,8 +192,8 @@ public final class Utility {
   }
 
   /**
-   * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
-   * contained in the graph
+   * Converts a Guava graph containing nodes of type GraphNode into a set of names
+   * of nodes contained in the graph
    *
    * @param graph the graph to return node names for
    * @return a set of names of nodes in the graph
@@ -206,14 +203,14 @@ public final class Utility {
   }
 
   /**
-   * Filters the mutations contained in this multimutation to be only the ones that affect the nodes
-   * in the provided set
+   * Filters the mutations contained in this multimutation to be only the ones
+   * that affect the nodes in the provided set
    *
-   * @param mm the multimutation to filter
+   * @param mm        the multimutation to filter
    * @param nodeNames the list of node names to return perninent mutations for
-   * @return a multimutation containing only those mutations in mm affecting nodes in nodeNames,
-   *     null if the multimutation is null and the multimutation itself if there is no name to
-   *     filter by
+   * @return a multimutation containing only those mutations in mm affecting nodes
+   *         in nodeNames, null if the multimutation is null and the multimutation
+   *         itself if there is no name to filter by
    */
   public static MultiMutation filterMultiMutationByNodes(MultiMutation mm, Set<String> nodeNames) {
     if (mm == null || nodeNames.size() == 0) {
@@ -228,18 +225,30 @@ public final class Utility {
         filteredMutationList.add(mut);
       }
     }
-    return MultiMutation.newBuilder()
-        .addAllMutation(filteredMutationList)
-        .setReason(mm.getReason())
-        .build();
+    return MultiMutation.newBuilder().addAllMutation(filteredMutationList).setReason(mm.getReason()).build();
   }
 
-  public static List<Integer> findRelevantMutations(
-      Set<String> nodeNames,
-      Map<String, List<Integer>> mutationIndicesMap,
-      List<MultiMutation> multiMutList) {
+  /**
+   * Given a list of node names, a map from node name to mutation indices of that node and
+   * a list of multimutations applied to all nodes, returns a list of indices of multimutations
+   * in which any of the nodes in nodeNames get mutated (returned in sorted order)
+   * @param nodeNames the names of nodes to restrict the returned list of mutations to
+   * @param mutationIndicesMap a map from node name -> indices of mutations that mutate it
+   * @param multiMutList a list of multimutations which mutationIndices map indexes into
+   * @return a list of indices in multiMutList at which any of the nodes in nodeNames 
+   * are mutated
+   * Might modify mutationIndices map by caching information about relevant mutation
+   * indices of some nodes 
+   */
+  public static List<Integer> findRelevantMutations(Set<String> nodeNames,
+      Map<String, List<Integer>> mutationIndicesMap, List<MultiMutation> multiMutList) {
     Set<Integer> relevantIndices = new HashSet<>();
     for (String nodeName : nodeNames) {
+      // No node name should be an empty string
+      if(nodeName.equals("")) {
+        continue;
+      }
+      // Find or compute and cache the relevant mutation indices for each node
       if (!mutationIndicesMap.containsKey(nodeName)) {
         mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
       }

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -60,3 +60,12 @@ mutation {
 }
 reason: "Changing tokens of node B"
 }
+mutation {
+mutation {
+  type: DELETE_EDGE
+  start_node: "A"
+  end_node: "C"
+}
+reason: "Removing edge AC"
+
+}

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -791,7 +791,9 @@ function getClosestIndices(indicesList, element) {
     }
   }
   toReturn['higher'] = indexHigher;
-  toReturn['lower'] = indicesList[indexHigher - 1] < element ? indexHigher - 1 : Math.max(indexHigher - 2, -1);
+  // if indexHigher is 0, then nothing is less (so lower is -1)
+  // otherwise check the previous element and either go back by 1 or 2
+  toReturn['lower'] = indexHigher === 0 ? -1 : (indicesList[indexHigher - 1] < element ? indexHigher - 1 : Math.max(indexHigher - 2, -1));
   return toReturn;
 }
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -147,7 +147,7 @@ async function generateGraph() {
   }
 
   // There aren't any nodes in this graph, and there aren't any mutations pertaining to the filtered node
-  if (nodes.length === 0 && numMutations === 0) {
+  if (nodes.length === 0 && numMutations === 0 && mutList.length == 0) {
     displayError("This node does not exist in any stage of the graph!");
     return;
   } else if (response.headers.get("serverMessage")) {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -130,6 +130,7 @@ async function generateGraph() {
 
   mutationIndexList = JSON.parse(jsonResponse.mutationIndices);
   numMutations = mutationIndexList.length;
+  console.log(mutationIndexList);
 
   if (!nodes || !edges || !Array.isArray(nodes) || !Array.isArray(edges)) {
     displayError("Malformed graph received from server - edges or nodes are empty");

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -153,6 +153,7 @@ async function generateGraph() {
   const indexOfClosestSmallerNumber = getClosestIndices(mutationIndexList, currMutationNum).lower;
   
   currMutationIndex = ((indexOfNextLargerNumber + indexOfClosestSmallerNumber) / 2);
+  console.log(currMutationIndex);
 
   // Add node to array of cytoscape nodes
   nodes.forEach(node =>


### PR DESCRIPTION
In this PR, I:
- added code so that when the user filters a graph by node name or limits the radius of display, clicking next goes to the next graph where any on-screen nodes are mutated instead of going to the next graph where any node (possibly not displayed) is mutated.
- added backend tests for the added logic