### PR TITLE
Allow for filtering by token across multiple graphs

### DIFF
--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -253,7 +253,7 @@ abstract class DataGraph {
           for (String token : startNode.tokenList()) {
             removeNodeFromToken(token, startName);
           }
-
+          
           Set<GraphNode> successors = graph.successors(startNode);
 
           roots.remove(startName);

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -249,6 +249,10 @@ abstract class DataGraph {
           if (startNode == null) { // Check node exists before removing
             return "Delete node: Deleting a non-existent node " + startName + "\n";
           }
+          for(String token : startNode.tokenList()) {
+            removeToken(token, startName);
+          }
+
           Set<GraphNode> successors = graph.successors(startNode);
 
           roots.remove(startName);

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -437,7 +437,7 @@ abstract class DataGraph {
 
     boolean nothingSearched =
         false; // True if nothing was searched. Ensures that the empty string is not mistaken for a
-               // node
+    // node
     for (String name : names) {
       // add the nodes that exist, ignore the ones that don'e
       if (name.length() == 0) {

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -249,8 +249,9 @@ abstract class DataGraph {
           if (startNode == null) { // Check node exists before removing
             return "Delete node: Deleting a non-existent node " + startName + "\n";
           }
+          // Remove the node from all of the occurrences in the tokenMap
           for (String token : startNode.tokenList()) {
-            removeToken(token, startName);
+            removeNodeFromToken(token, startName);
           }
 
           Set<GraphNode> successors = graph.successors(startNode);
@@ -266,14 +267,7 @@ abstract class DataGraph {
               roots.add(succ.name());
             }
           }
-          // Remove the node from all of the occurrences in the tokenMap
-          for (String token : this.tokenMap().keySet()) {
-            this.tokenMap().get(token).remove(startName);
-            // Check if it's empty
-            if (this.tokenMap().get(token).isEmpty()) {
-              this.tokenMap().remove(token);
-            }
-          }
+
           break;
         }
       case CHANGE_TOKEN:

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -322,7 +322,6 @@ abstract class DataGraph {
 
     TokenMutation.Type tokenMutType = tokenMut.getType();
     if (tokenMutType == TokenMutation.Type.ADD_TOKEN) {
-      tokenNames.removeAll(tokenList);
       tokenList.addAll(tokenNames);
 
       // Update the map
@@ -330,7 +329,6 @@ abstract class DataGraph {
         addNodeToToken(tokenName, node.name());
       }
     } else if (tokenMutType == TokenMutation.Type.DELETE_TOKEN) {
-      tokenNames.removeIf(elem -> !(tokenList.contains(elem)));
       tokenList.removeAll(tokenNames);
       // Update the map
       for (String tokenName : tokenNames) {

--- a/src/main/java/com/google/sps/DataGraph.java
+++ b/src/main/java/com/google/sps/DataGraph.java
@@ -249,7 +249,7 @@ abstract class DataGraph {
           if (startNode == null) { // Check node exists before removing
             return "Delete node: Deleting a non-existent node " + startName + "\n";
           }
-          for(String token : startNode.tokenList()) {
+          for (String token : startNode.tokenList()) {
             removeToken(token, startName);
           }
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -74,7 +74,7 @@ public class DataServlet extends HttpServlet {
     if (currDataGraph == null && originalDataGraph == null) {
       success =
           initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
+              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       if (!success) {
         response.setHeader(
             "serverError", "Failed to parse input graph into Guava graph - not a DAG!");
@@ -93,7 +93,7 @@ public class DataServlet extends HttpServlet {
      */
     if (mutList == null) {
       initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
+          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size()).boxed().collect(Collectors.toList());
       // and store this as the list of relevant indices for filtering by empty string

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -205,7 +205,8 @@ public class DataServlet extends HttpServlet {
       // A set containing a indices where nodes currently displayed on the graph
       // or queried are mutated
       Set<Integer> mutationIndicesSet = new HashSet<>();
-      mutationIndicesSet.addAll(Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList));
+      mutationIndicesSet.addAll(
+          Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList));
       mutationIndicesSet.addAll(Utility.getMutationIndicesOfTokenSet(tokenParam, mutList));
       filteredMutationIndices = new ArrayList<>(mutationIndicesSet);
       Collections.sort(filteredMutationIndices);
@@ -215,7 +216,8 @@ public class DataServlet extends HttpServlet {
       } else {
         // In this case, also show mutations relevant to nodes that used to have the token but
         // might not exist anymore
-        filteredDiff = Utility.filterMultiMutationByNodes(diff, Sets.union(truncatedGraphNodeNames, queried));
+        filteredDiff =
+            Utility.filterMultiMutationByNodes(diff, Sets.union(truncatedGraphNodeNames, queried));
       }
     }
     // We set the headers in the following 4 scenarios:
@@ -234,28 +236,29 @@ public class DataServlet extends HttpServlet {
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       response.setHeader(
           "serverMessage",
-          "The searched node/token does not exist in this graph, so nothing is shown. However, it is"
-              + " mutated at some other step. Please click next or previous to navigate to a graph"
-              + " where this node exists.");
+          "The searched node/token does not exist in this graph, so nothing is shown. However, it"
+              + " is mutated at some other step. Please click next or previous to navigate to a"
+              + " graph where this node exists.");
     }
     // The searched node exists but is not mutated in the current graph
-    if (truncatedGraph.nodes().size() != 0 &&
-          !(mutationNumber == -1 && nodeNameParam.equals("") && tokenParam.equals("")) &&
-          filteredMutationIndices.indexOf(mutationNumber) == -1) {
-          if(diff == null || diff.getMutationList().size() == 0) {
-            response.setHeader(
-                "serverMessage",
-                "The searched node/token exists in this graph. However, it is not mutated in this graph."
-                    + " Please click next or previous if you wish to see where it was mutated!");
-          } else {
-            if(filteredDiff == null || filteredDiff.getMutationList().size() == 0) {
-              response.setHeader(
-                  "serverMessage",
-                  "The searched node/token exists in this graph and is not mutated in this graph."
-                      + " However, some other previously displayed node is mutated. Please clear your"
-                      + " filter to view this mutation");
-            }
-          }
+    if (truncatedGraph.nodes().size() != 0
+        && !(mutationNumber == -1 && nodeNameParam.equals("") && tokenParam.equals(""))
+        && filteredMutationIndices.indexOf(mutationNumber) == -1) {
+      if (diff == null || diff.getMutationList().size() == 0) {
+        response.setHeader(
+            "serverMessage",
+            "The searched node/token exists in this graph. However, it is not mutated in this"
+                + " graph. Please click next or previous if you wish to see where it was"
+                + " mutated!");
+      } else {
+        if (filteredDiff == null || filteredDiff.getMutationList().size() == 0) {
+          response.setHeader(
+              "serverMessage",
+              "The searched node/token exists in this graph and is not mutated in this graph."
+                  + " However, some other previously displayed node is mutated. Please clear your"
+                  + " filter to view this mutation");
+        }
+      }
     }
 
     // There is a diff between the previously-displayed graph and the current graph but
@@ -270,7 +273,8 @@ public class DataServlet extends HttpServlet {
               + " to view the mutation.");
     }
     graphJson =
-        Utility.graphToJson(truncatedGraph, filteredMutationIndices, filteredDiff, mutList.size(), queried);
+        Utility.graphToJson(
+            truncatedGraph, filteredMutationIndices, filteredDiff, mutList.size(), queried);
     response.getWriter().println(graphJson);
   }
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -187,7 +187,7 @@ public class DataServlet extends HttpServlet {
 
     // Truncate the graph from the nodes that the client had searched for
     truncatedGraph = currDataGraph.getReachableNodes(queried, depthNumber);
-    // OPT: check queried and currDataGraph.tokenMap().get(tokenParam) are the same
+   
     MutableGraph<GraphNode> truncatedGraphNext =
         currDataGraph.getReachableNodes(currDataGraph.tokenMap().get(tokenParam), depthNumber);
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -17,7 +17,6 @@ package com.google.sps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.io.InputStreamReader;
 
 import java.util.List;
@@ -230,7 +229,7 @@ public class DataServlet extends HttpServlet {
 
     // If we are not filtering the graph or limiting its depth, show all mutations of all nodes
     if (nodeNameParam.length() == 0 && truncatedGraph.equals(currDataGraph.graph())) {
-      
+
       filteredMutationIndices = defaultIndices;
     } else {
       // Get the names of all the displayed nodes and find all indices of mutations

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -70,9 +70,7 @@ public class DataServlet extends HttpServlet {
      *********************************
      */
     if (currDataGraph == null && originalDataGraph == null) {
-      success =
-          initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
+      success = initializeGraphVariables(getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       String error = "Failed to parse input graph into Guava graph - not a DAG!";
       if (!success) {
         response.setHeader("serverError", error);
@@ -91,8 +89,7 @@ public class DataServlet extends HttpServlet {
      *************************************
      */
     if (mutList == null) {
-      initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
+      initializeMutationVariables(getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size() - 1).boxed().collect(Collectors.toList());
       // and initialize the current list of relevant indices to this because
@@ -157,29 +154,32 @@ public class DataServlet extends HttpServlet {
     // Find the indices that mutate the searched node, computing and caching them
     // if this has not been done already
     if (!mutationIndicesMap.containsKey(nodeNameParam)) {
-      mutationIndicesMap.put(
-          nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
+      mutationIndicesMap.put(nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
     }
 
     List<String> queried = new ArrayList<>();
     List<List<Integer>> allRelevantMutationIndices = new ArrayList<>();
 
+    // Possible cominations of nodeName and token:
     // Both empty -> can just look at nodeNameParam
     // nodeName nonempty, token empty -> just look at nodeNameParam
     // nodeName empty, token nonempty -> look only at token
     // Both nondempty -> look at both
-    // So we look at nodeName param in the case that both are empty and token is empty
+    // So we look at nodeName param in the case that both are empty and token is
+    // empty
 
-    // nodeNameParam is relevant in this case. otherwise this means tokenParam is not empty, and we
-    // should
-    // statement is shortened from tokenParam.length() == 0 || (tokenParam.length() != 0 &&
+    // nodeNameParam is relevant in these case. otherwise this means tokenParam is
+    // not empty but nodeName is, so we should not consider the nodeNameParam.
+    // statement is shortened from tokenParam.length() == 0 || (tokenParam.length()
+    // != 0 &&
     // nodeNameParam.length() != 0)
     if (tokenParam.length() == 0 || nodeNameParam.length() != 0) {
       queried.add(nodeNameParam);
       allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));
     }
 
-    // Process the tokens here - if tokens are empty it won't be in the map, this won't happen
+    // Process the tokens here - if tokens are empty it won't be in the map, this
+    // won't happen
     // If the token is contained, then get the nodes associated with the token and
     // add them to the queried nodes
     if (currDataGraph.tokenMap().containsKey(tokenParam)) {
@@ -196,8 +196,7 @@ public class DataServlet extends HttpServlet {
     filteredMutationIndices = Utility.mergeSortedLists(allRelevantMutationIndices);
 
     // Get the graph at the requested mutation number and truncate it
-    currDataGraph =
-        Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
+    currDataGraph = Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
 
     truncatedGraph = currDataGraph.getReachableNodes(queried, depthNumber);
 
@@ -210,12 +209,10 @@ public class DataServlet extends HttpServlet {
     }
     if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() != 0) {
       // The searched node is not in the graph but is mutated at some future point
-      String message =
-          "The searched node does not exist in this graph, but it does exist in a later graph!";
+      String message = "The searched node does not exist in this graph, but it does exist in a later graph!";
       response.setHeader("serverMessage", message);
     }
-    if (truncatedGraph.nodes().size() != 0
-        && mutationNumber != -1
+    if (truncatedGraph.nodes().size() != 0 && mutationNumber != -1
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       // The searched node exists but is not mutated in the current graph
       String message = "The searched node exists, but is not mutated in this graph";
@@ -232,11 +229,12 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intitialize graph variables. returns a boolean to represent whether the
-   * InpuStream was read successfully.
+   * Private function to intitialize graph variables. returns a boolean to
+   * represent whether the InpuStream was read successfully.
    *
    * @param graphInput InputStream to initialize graph variables over
-   * @return whether variables were initialized properly; true if successful and false otherwise
+   * @return whether variables were initialized properly; true if successful and
+   *         false otherwise
    * @throws IOException if something does wrong during the reading
    */
   private boolean initializeGraphVariables(InputStream graphInput) throws IOException {
@@ -251,8 +249,8 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intialize the mutation list. Returns a boolean to represent whether the
-   * InputStream was read successfully.
+   * Private function to intialize the mutation list. Returns a boolean to
+   * represent whether the InputStream was read successfully.
    *
    * @param mutationInput InputStream to initialize variable over
    * @throws IOException if something goes wrong during the reading

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -207,8 +207,8 @@ public class DataServlet extends HttpServlet {
       // or queried are mutated
       Set<Integer> mutationIndicesSet = new HashSet<>();
       mutationIndicesSet.addAll(
-          Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList));
-      mutationIndicesSet.addAll(Utility.getMutationIndicesOfTokenSet(tokenParam, mutList));
+          Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList));
+      mutationIndicesSet.addAll(Utility.getMutationIndicesOfToken(tokenParam, mutList));
       filteredMutationIndices = new ArrayList<>(mutationIndicesSet);
       Collections.sort(filteredMutationIndices);
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -205,12 +205,11 @@ public class DataServlet extends HttpServlet {
       //     Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
       Set<Integer> nodeIndices =
           Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList);
-      // TODO: add token indices to filteredMutationIndices
-      List<Integer> tokenIndices = Utility.getMutationIndicesOfToken(tokenParam, mutList);
+      Set<Integer> tokenIndices = Utility.getMutationIndicesOfTokenSet(tokenParam, mutList);
       tokenIndices.addAll(nodeIndices);
-      Collections.sort(tokenIndices);
-      filteredMutationIndices = tokenIndices;
-
+      filteredMutationIndices = new ArrayList<>(tokenIndices);
+      Collections.sort(filteredMutationIndices);
+     
       // Filter the diff to only show mutations relevant to the above nodes
       diff = Utility.filterMultiMutationByNodes(diff, truncatedGraphNodeNames);
     }

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -203,6 +203,7 @@ public class DataServlet extends HttpServlet {
       }
       // filteredMutationIndices =
       //     Utility.findRelevantMutations(truncatedGraphNodeNames, mutationIndicesMap, mutList);
+      // Create a set for the mutations of the nodes in the graph and a set for the token. Add and sort
       Set<Integer> nodeIndices =
           Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList);
       Set<Integer> tokenIndices = Utility.getMutationIndicesOfTokenSet(tokenParam, mutList);

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -244,22 +244,13 @@ public class DataServlet extends HttpServlet {
     // The searched node exists but is not mutated in the current graph
     if (truncatedGraph.nodes().size() != 0
         && !(mutationNumber == -1 && nodeNameParam.equals("") && tokenParam.equals(""))
-        && filteredMutationIndices.indexOf(mutationNumber) == -1) {
-      if (diff == null || diff.getMutationList().size() == 0) {
+        && filteredMutationIndices.indexOf(mutationNumber) == -1 &&
+        (diff == null || diff.getMutationList().size() == 0)) {
         response.setHeader(
             "serverMessage",
             "The searched node/token exists in this graph. However, it is not mutated in this"
                 + " graph. Please click next or previous if you wish to see where it was"
                 + " mutated!");
-      } else {
-        if (filteredDiff == null || filteredDiff.getMutationList().size() == 0) {
-          response.setHeader(
-              "serverMessage",
-              "The searched node/token exists in this graph and is not mutated in this graph."
-                  + " However, some other previously displayed node is mutated. Please clear your"
-                  + " filter to view this mutation");
-        }
-      }
     }
 
     // There is a diff between the previously-displayed graph and the current graph but
@@ -270,8 +261,8 @@ public class DataServlet extends HttpServlet {
       response.setHeader(
           "serverMessage",
           "The desired set of nodes is mutated in this graph but your other parameters (for"
-              + " eg.depth), limit the display of the mutations. Please try increasing your radius"
-              + " to view the mutation.");
+              + " eg.depth or filter), limit the display of the mutations. Please try increasing "
+              + " your radius or clearing your filter to view the mutation.");
     }
     graphJson =
         Utility.graphToJson(

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -70,7 +70,9 @@ public class DataServlet extends HttpServlet {
      *********************************
      */
     if (currDataGraph == null && originalDataGraph == null) {
-      success = initializeGraphVariables(getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
+      success =
+          initializeGraphVariables(
+              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       String error = "Failed to parse input graph into Guava graph - not a DAG!";
       if (!success) {
         response.setHeader("serverError", error);
@@ -89,7 +91,8 @@ public class DataServlet extends HttpServlet {
      *************************************
      */
     if (mutList == null) {
-      initializeMutationVariables(getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
+      initializeMutationVariables(
+          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size() - 1).boxed().collect(Collectors.toList());
       // and initialize the current list of relevant indices to this because
@@ -154,7 +157,8 @@ public class DataServlet extends HttpServlet {
     // Find the indices that mutate the searched node, computing and caching them
     // if this has not been done already
     if (!mutationIndicesMap.containsKey(nodeNameParam)) {
-      mutationIndicesMap.put(nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
+      mutationIndicesMap.put(
+          nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
     }
 
     List<String> queried = new ArrayList<>();
@@ -196,7 +200,8 @@ public class DataServlet extends HttpServlet {
     filteredMutationIndices = Utility.mergeSortedLists(allRelevantMutationIndices);
 
     // Get the graph at the requested mutation number and truncate it
-    currDataGraph = Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
+    currDataGraph =
+        Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
 
     truncatedGraph = currDataGraph.getReachableNodes(queried, depthNumber);
 
@@ -209,10 +214,12 @@ public class DataServlet extends HttpServlet {
     }
     if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() != 0) {
       // The searched node is not in the graph but is mutated at some future point
-      String message = "The searched node does not exist in this graph, but it does exist in a later graph!";
+      String message =
+          "The searched node does not exist in this graph, but it does exist in a later graph!";
       response.setHeader("serverMessage", message);
     }
-    if (truncatedGraph.nodes().size() != 0 && mutationNumber != -1
+    if (truncatedGraph.nodes().size() != 0
+        && mutationNumber != -1
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       // The searched node exists but is not mutated in the current graph
       String message = "The searched node exists, but is not mutated in this graph";
@@ -229,12 +236,11 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intitialize graph variables. returns a boolean to
-   * represent whether the InpuStream was read successfully.
+   * Private function to intitialize graph variables. returns a boolean to represent whether the
+   * InpuStream was read successfully.
    *
    * @param graphInput InputStream to initialize graph variables over
-   * @return whether variables were initialized properly; true if successful and
-   *         false otherwise
+   * @return whether variables were initialized properly; true if successful and false otherwise
    * @throws IOException if something does wrong during the reading
    */
   private boolean initializeGraphVariables(InputStream graphInput) throws IOException {
@@ -249,8 +255,8 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intialize the mutation list. Returns a boolean to
-   * represent whether the InputStream was read successfully.
+   * Private function to intialize the mutation list. Returns a boolean to represent whether the
+   * InputStream was read successfully.
    *
    * @param mutationInput InputStream to initialize variable over
    * @throws IOException if something goes wrong during the reading

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -77,7 +77,7 @@ public class DataServlet extends HttpServlet {
     if (currDataGraph == null && originalDataGraph == null) {
       success =
           initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
+              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       if (!success) {
         response.setHeader(
             "serverError", "Failed to parse input graph into Guava graph - not a DAG!");
@@ -96,7 +96,7 @@ public class DataServlet extends HttpServlet {
      */
     if (mutList == null) {
       initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
+          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size()).boxed().collect(Collectors.toList());
       // and store this as the list of relevant indices for filtering by empty string

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -164,11 +164,11 @@ public class DataServlet extends HttpServlet {
     List<String> queried = new ArrayList<>();
     List<List<Integer>> allRelevantMutationIndices = new ArrayList<>();
 
-    // Possible cominations of nodeName and token:
-    // Both empty -> can just look at nodeNameParam
-    // nodeName nonempty, token empty -> just look at nodeNameParam
-    // nodeName empty, token nonempty -> look only at token
-    // Both nondempty -> look at both
+    // Possible combinations of nodeName and token:
+    // 1. Both empty -> can just look at nodeNameParam
+    // 2. nodeName nonempty, token empty -> just look at nodeNameParam
+    // 3. nodeName empty, token nonempty -> look only at token
+    // 4. Both nondempty -> look at both
     // So we look at nodeName param in the case that both are empty and token is
     // empty
 
@@ -181,8 +181,8 @@ public class DataServlet extends HttpServlet {
       queried.add(nodeNameParam);
       allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));
     }
-    allRelevantMutationIndices.add(Utility.getMutationIndicesOfNode(tokenParam, mutList));
-    // DO WE NEED THIS???
+    allRelevantMutationIndices.add(Utility.getMutationIndicesOfToken(tokenParam, mutList));
+    
     // Process the tokens here - if tokens are empty it won't be in the map, this
     // won't happen
     // If the token is contained, then get the nodes associated with the token and
@@ -197,9 +197,8 @@ public class DataServlet extends HttpServlet {
       }
     }
 
-    // Get a sorted one
+    // Get a sorted indice list with everything
     filteredMutationIndices = Utility.mergeSortedLists(allRelevantMutationIndices);
-
     // Get the graph at the requested mutation number and truncate it
     currDataGraph =
         Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -182,7 +182,7 @@ public class DataServlet extends HttpServlet {
       allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));
     }
     allRelevantMutationIndices.add(Utility.getMutationIndicesOfToken(tokenParam, mutList));
-    
+
     // Process the tokens here - if tokens are empty it won't be in the map, this
     // won't happen
     // If the token is contained, then get the nodes associated with the token and

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -157,14 +157,23 @@ public class DataServlet extends HttpServlet {
     if (!mutationIndicesMap.containsKey(nodeNameParam)) {
       mutationIndicesMap.put(nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
     }
-    // filteredMutationIndices = mutationIndicesMap.get(nodeNameParam);
-    // Add the indices for the nodeNameParam to the list
-    List<List<Integer>> allRelevantMutationIndices = new ArrayList<>(Arrays.asList(mutationIndicesMap.get(nodeNameParam)));
-    allRelevantMutationIndices.add(filteredMutationIndices);
-    // ALl relevant nodes we are concerned about, first add node name
-    List<String> queried = new ArrayList<>(Arrays.asList(nodeNameParam));
+    List<String> queried = new ArrayList<>();
+    List<List<Integer>> allRelevantMutationIndices = new ArrayList<>();
 
-    // Process the tokens here
+    // Both empty -> can just look at nodeNameParam
+    // nodeName nonempty, token empty -> just look at nodeNameParam
+    // nodeName empty, token nonempty -> look only at token
+    // Both nondempty -> look at both
+    // So we look at nodeName param in the case that both are empty and token is empty 
+
+    // nodeNameParam is relevant in this case. otherwise this means tokenParam is not empty, and we should 
+    // statement is shortened from tokenParam.length() == 0 || (tokenParam.length() != 0 && nodeNameParam.length() != 0)
+    if (tokenParam.length() == 0 || nodeNameParam.length() != 0) {
+      queried.add(nodeNameParam);
+      allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));
+    }
+
+    // Process the tokens here - if tokens are empty it won't be in the map, this won't happen
     // If the token is contained, then get the nodes associated with the token and
     // add them to the queried nodes
     if (currDataGraph.tokenMap().containsKey(tokenParam)) {

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -181,7 +181,8 @@ public class DataServlet extends HttpServlet {
       queried.add(nodeNameParam);
       allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));
     }
-
+    allRelevantMutationIndices.add(Utility.getMutationIndicesOfNode(tokenParam, mutList));
+    // DO WE NEED THIS???
     // Process the tokens here - if tokens are empty it won't be in the map, this
     // won't happen
     // If the token is contained, then get the nodes associated with the token and

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -71,7 +71,9 @@ public class DataServlet extends HttpServlet {
      *********************************
      */
     if (currDataGraph == null && originalDataGraph == null) {
-      success = initializeGraphVariables(getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
+      success =
+          initializeGraphVariables(
+              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       String error = "Failed to parse input graph into Guava graph - not a DAG!";
       if (!success) {
         response.setHeader("serverError", error);
@@ -90,7 +92,8 @@ public class DataServlet extends HttpServlet {
      *************************************
      */
     if (mutList == null) {
-      initializeMutationVariables(getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
+      initializeMutationVariables(
+          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size() - 1).boxed().collect(Collectors.toList());
       // and initialize the current list of relevant indices to this because
@@ -155,12 +158,14 @@ public class DataServlet extends HttpServlet {
     // Find the indices that mutate the searched node, computing and caching them
     // if this has not been done already
     if (!mutationIndicesMap.containsKey(nodeNameParam)) {
-      mutationIndicesMap.put(nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
+      mutationIndicesMap.put(
+          nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
     }
     filteredMutationIndices = mutationIndicesMap.get(nodeNameParam);
 
     // Get the graph at the requested mutation number and truncate it
-    currDataGraph = Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
+    currDataGraph =
+        Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
 
     List<String> queried = new ArrayList<>(Arrays.asList(nodeNameParam));
     // If the token is contained, then get the nodes associated with the token and
@@ -179,10 +184,12 @@ public class DataServlet extends HttpServlet {
     }
     if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() != 0) {
       // The searched node is not in the graph but is mutated at some future point
-      String message = "The searched node does not exist in this graph, but it does exist in a later graph!";
+      String message =
+          "The searched node does not exist in this graph, but it does exist in a later graph!";
       response.setHeader("serverMessage", message);
     }
-    if (truncatedGraph.nodes().size() != 0 && mutationNumber != -1
+    if (truncatedGraph.nodes().size() != 0
+        && mutationNumber != -1
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       // The searched node exists but is not mutated in the current graph
       String message = "The searched node exists, but is not mutated in this graph";
@@ -199,12 +206,11 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intitialize graph variables. returns a boolean to
-   * represent whether the InpuStream was read successfully.
+   * Private function to intitialize graph variables. returns a boolean to represent whether the
+   * InpuStream was read successfully.
    *
    * @param graphInput InputStream to initialize graph variables over
-   * @return whether variables were initialized properly; true if successful and
-   *         false otherwise
+   * @return whether variables were initialized properly; true if successful and false otherwise
    * @throws IOException if something does wrong during the reading
    */
   private boolean initializeGraphVariables(InputStream graphInput) throws IOException {
@@ -219,8 +225,8 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intialize the mutation list. Returns a boolean to
-   * represent whether the InputStream was read successfully.
+   * Private function to intialize the mutation list. Returns a boolean to represent whether the
+   * InputStream was read successfully.
    *
    * @param mutationInput InputStream to initialize variable over
    * @throws IOException if something goes wrong during the reading

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -17,7 +17,6 @@ package com.google.sps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.io.InputStreamReader;
 
 import java.util.List;
@@ -169,10 +168,12 @@ public class DataServlet extends HttpServlet {
     // nodeName nonempty, token empty -> just look at nodeNameParam
     // nodeName empty, token nonempty -> look only at token
     // Both nondempty -> look at both
-    // So we look at nodeName param in the case that both are empty and token is empty 
+    // So we look at nodeName param in the case that both are empty and token is empty
 
-    // nodeNameParam is relevant in this case. otherwise this means tokenParam is not empty, and we should 
-    // statement is shortened from tokenParam.length() == 0 || (tokenParam.length() != 0 && nodeNameParam.length() != 0)
+    // nodeNameParam is relevant in this case. otherwise this means tokenParam is not empty, and we
+    // should
+    // statement is shortened from tokenParam.length() == 0 || (tokenParam.length() != 0 &&
+    // nodeNameParam.length() != 0)
     if (tokenParam.length() == 0 || nodeNameParam.length() != 0) {
       queried.add(nodeNameParam);
       allRelevantMutationIndices.add(mutationIndicesMap.get(nodeNameParam));

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -244,13 +244,13 @@ public class DataServlet extends HttpServlet {
     // The searched node exists but is not mutated in the current graph
     if (truncatedGraph.nodes().size() != 0
         && !(mutationNumber == -1 && nodeNameParam.equals("") && tokenParam.equals(""))
-        && filteredMutationIndices.indexOf(mutationNumber) == -1 &&
-        (diff == null || diff.getMutationList().size() == 0)) {
-        response.setHeader(
-            "serverMessage",
-            "The searched node/token exists in this graph. However, it is not mutated in this"
-                + " graph. Please click next or previous if you wish to see where it was"
-                + " mutated!");
+        && filteredMutationIndices.indexOf(mutationNumber) == -1
+        && (diff == null || diff.getMutationList().size() == 0)) {
+      response.setHeader(
+          "serverMessage",
+          "The searched node/token exists in this graph. However, it is not mutated in this"
+              + " graph. Please click next or previous if you wish to see where it was"
+              + " mutated!");
     }
 
     // There is a diff between the previously-displayed graph and the current graph but

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -212,12 +212,17 @@ public class DataServlet extends HttpServlet {
       // sort
       Set<Integer> nodeIndices = new HashSet<>();
       if (tokenParam.length() == 0) {
-        nodeIndices = Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList);
+        nodeIndices =
+            Utility.findRelevantMutationsSet(truncatedGraphNodeNames, mutationIndicesMap, mutList);
         diff = Utility.filterMultiMutationByNodes(diff, truncatedGraphNodeNames);
       } else {
         System.out.println("Queried " + queried);
         System.out.println("Diff " + diff);
-        nodeIndices = Utility.findRelevantMutationsSet(currDataGraph.tokenMap().getOrDefault(tokenParam, new HashSet<String>()), mutationIndicesMap, mutList);
+        nodeIndices =
+            Utility.findRelevantMutationsSet(
+                currDataGraph.tokenMap().getOrDefault(tokenParam, new HashSet<String>()),
+                mutationIndicesMap,
+                mutList);
         nodeIndices.addAll(Utility.getMutationIndicesOfToken(tokenParam, mutList));
         Set<String> newSet = new HashSet<String>();
         newSet.addAll(truncatedGraphNodeNames);
@@ -225,9 +230,9 @@ public class DataServlet extends HttpServlet {
         diff = Utility.filterMultiMutationByNodes(diff, newSet);
         System.out.println("Filtered diff " + diff);
       }
-       
-      //Set<Integer> tokenIndices = Utility.getMutationIndicesOfTokenSet(tokenParam, mutList);
-      //tokenIndices.addAll(nodeIndices);
+
+      // Set<Integer> tokenIndices = Utility.getMutationIndicesOfTokenSet(tokenParam, mutList);
+      // tokenIndices.addAll(nodeIndices);
       filteredMutationIndices = new ArrayList<>(nodeIndices);
       Collections.sort(filteredMutationIndices);
 

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -189,7 +189,9 @@ public class DataServlet extends HttpServlet {
     truncatedGraph = currDataGraph.getReachableNodes(queried, depthNumber);
 
     // If we are not filtering the graph or limiting its depth, show all mutations of all nodes
-    if (nodeNameParam.length() == 0 && tokenParam.length() == 0 && truncatedGraph.equals(currDataGraph.graph())) {
+    if (nodeNameParam.length() == 0
+        && tokenParam.length() == 0
+        && truncatedGraph.equals(currDataGraph.graph())) {
       filteredMutationIndices = defaultIndices;
     } else {
       // Get the names of all the displayed nodes and find all indices of mutations
@@ -235,11 +237,12 @@ public class DataServlet extends HttpServlet {
     }
     // The searched node exists but is not mutated in the current graph
     if (truncatedGraph.nodes().size() != 0
-    // this message should only appear if we're not at the initial graph and if something was searched
+        // this message should only appear if we're not at the initial graph and if something was
+        // searched
         && !(mutationNumber == -1 && nodeNameParam.equals(""))
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
-          System.out.println(mutationNumber);
-          System.out.println(filteredMutationIndices);
+      System.out.println(mutationNumber);
+      System.out.println(filteredMutationIndices);
       response.setHeader(
           "serverMessage",
           "The searched node exists in this graph! However, it is not mutated in this graph."

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -77,7 +77,7 @@ public class DataServlet extends HttpServlet {
     if (currDataGraph == null && originalDataGraph == null) {
       success =
           initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
+              getServletContext().getResourceAsStream("/WEB-INF/graph.textproto"));
       if (!success) {
         response.setHeader(
             "serverError", "Failed to parse input graph into Guava graph - not a DAG!");
@@ -96,7 +96,7 @@ public class DataServlet extends HttpServlet {
      */
     if (mutList == null) {
       initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
+          getServletContext().getResourceAsStream("/WEB-INF/mutation.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size()).boxed().collect(Collectors.toList());
       // and store this as the list of relevant indices for filtering by empty string
@@ -193,6 +193,7 @@ public class DataServlet extends HttpServlet {
         && tokenParam.length() == 0
         && truncatedGraph.equals(currDataGraph.graph())) {
       filteredMutationIndices = defaultIndices;
+      filteredDiff = diff;
     } else {
       // Get the names of all the displayed nodes and find all indices of mutations
       // that mutate any of them

--- a/src/main/java/com/google/sps/DataServlet.java
+++ b/src/main/java/com/google/sps/DataServlet.java
@@ -71,9 +71,7 @@ public class DataServlet extends HttpServlet {
      *********************************
      */
     if (currDataGraph == null && originalDataGraph == null) {
-      success =
-          initializeGraphVariables(
-              getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
+      success = initializeGraphVariables(getServletContext().getResourceAsStream("/WEB-INF/initial_graph.textproto"));
       String error = "Failed to parse input graph into Guava graph - not a DAG!";
       if (!success) {
         response.setHeader("serverError", error);
@@ -92,8 +90,7 @@ public class DataServlet extends HttpServlet {
      *************************************
      */
     if (mutList == null) {
-      initializeMutationVariables(
-          getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
+      initializeMutationVariables(getServletContext().getResourceAsStream("/WEB-INF/mutations.textproto"));
       // Populate the list of all possible mutation indices
       defaultIndices = IntStream.range(0, mutList.size() - 1).boxed().collect(Collectors.toList());
       // and initialize the current list of relevant indices to this because
@@ -158,21 +155,34 @@ public class DataServlet extends HttpServlet {
     // Find the indices that mutate the searched node, computing and caching them
     // if this has not been done already
     if (!mutationIndicesMap.containsKey(nodeNameParam)) {
-      mutationIndicesMap.put(
-          nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
+      mutationIndicesMap.put(nodeNameParam, Utility.getMutationIndicesOfNode(nodeNameParam, mutList));
     }
-    filteredMutationIndices = mutationIndicesMap.get(nodeNameParam);
-
-    // Get the graph at the requested mutation number and truncate it
-    currDataGraph =
-        Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
-
+    // filteredMutationIndices = mutationIndicesMap.get(nodeNameParam);
+    // Add the indices for the nodeNameParam to the list
+    List<List<Integer>> allRelevantMutationIndices = new ArrayList<>(Arrays.asList(mutationIndicesMap.get(nodeNameParam)));
+    allRelevantMutationIndices.add(filteredMutationIndices);
+    // ALl relevant nodes we are concerned about, first add node name
     List<String> queried = new ArrayList<>(Arrays.asList(nodeNameParam));
+
+    // Process the tokens here
     // If the token is contained, then get the nodes associated with the token and
     // add them to the queried nodes
     if (currDataGraph.tokenMap().containsKey(tokenParam)) {
       queried.addAll(currDataGraph.tokenMap().get(tokenParam));
+      for (String s : currDataGraph.tokenMap().get(tokenParam)) {
+        if (!mutationIndicesMap.containsKey(s)) {
+          mutationIndicesMap.put(s, Utility.getMutationIndicesOfNode(s, mutList));
+        }
+        allRelevantMutationIndices.add(mutationIndicesMap.get(s));
+      }
     }
+    
+    // Get a sorted one
+    filteredMutationIndices = Utility.mergeSortedLists(allRelevantMutationIndices);
+
+    // Get the graph at the requested mutation number and truncate it
+    currDataGraph = Utility.getGraphAtMutationNumber(originalDataGraph, currDataGraph, mutationNumber, mutList);
+
     truncatedGraph = currDataGraph.getReachableNodes(queried, depthNumber);
 
     // Handle errors
@@ -184,12 +194,10 @@ public class DataServlet extends HttpServlet {
     }
     if (truncatedGraph.nodes().size() == 0 && filteredMutationIndices.size() != 0) {
       // The searched node is not in the graph but is mutated at some future point
-      String message =
-          "The searched node does not exist in this graph, but it does exist in a later graph!";
+      String message = "The searched node does not exist in this graph, but it does exist in a later graph!";
       response.setHeader("serverMessage", message);
     }
-    if (truncatedGraph.nodes().size() != 0
-        && mutationNumber != -1
+    if (truncatedGraph.nodes().size() != 0 && mutationNumber != -1
         && filteredMutationIndices.indexOf(mutationNumber) == -1) {
       // The searched node exists but is not mutated in the current graph
       String message = "The searched node exists, but is not mutated in this graph";
@@ -206,11 +214,12 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intitialize graph variables. returns a boolean to represent whether the
-   * InpuStream was read successfully.
+   * Private function to intitialize graph variables. returns a boolean to
+   * represent whether the InpuStream was read successfully.
    *
    * @param graphInput InputStream to initialize graph variables over
-   * @return whether variables were initialized properly; true if successful and false otherwise
+   * @return whether variables were initialized properly; true if successful and
+   *         false otherwise
    * @throws IOException if something does wrong during the reading
    */
   private boolean initializeGraphVariables(InputStream graphInput) throws IOException {
@@ -225,8 +234,8 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Private function to intialize the mutation list. Returns a boolean to represent whether the
-   * InputStream was read successfully.
+   * Private function to intialize the mutation list. Returns a boolean to
+   * represent whether the InputStream was read successfully.
    *
    * @param mutationInput InputStream to initialize variable over
    * @throws IOException if something goes wrong during the reading

--- a/src/main/java/com/google/sps/JsonTest.java
+++ b/src/main/java/com/google/sps/JsonTest.java
@@ -21,6 +21,7 @@ import com.proto.GraphProtos.Node;
 import com.proto.GraphProtos.Node.Builder;
 import com.proto.MutationProtos.MultiMutation;
 import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -97,7 +98,7 @@ public final class JsonTest {
             new ArrayList<Integer>(),
             MultiMutation.newBuilder().setReason("test").build(),
             0,
-            new ArrayList<String>());
+            new HashSet<String>());
     JSONObject jsonObject = new JSONObject(result);
 
     Assert.assertEquals(jsonObject.length(), 7);

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -152,6 +152,7 @@ public class NodeMutationFilterTest {
     return multiMutList;
   }
 
+  // TESTING findRelevantMutations
   /**
    * Getting mutation indices of multiple nodes returns the union of all their individual indices in
    * sorted order

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -224,5 +224,4 @@ public class NodeMutationFilterTest {
     Assert.assertEquals(0, truncatedList.size());
     Assert.assertFalse(truncatedList.contains(0));
   }
-
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -30,10 +30,6 @@ import org.junit.runners.JUnit4;
 /** Test for functions within Utility that are used to filter graphs across nodes */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
-  // lst1 contains even number of elements
-  List<Integer> lst1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
-  // lst2 contains odd number of elements
-  List<Integer> lst2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
 
   // Following functions test the getMutationIndicesOfNode function in Utility
   /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
@@ -224,4 +220,33 @@ public class NodeMutationFilterTest {
     Assert.assertEquals(0, truncatedList.size());
     Assert.assertFalse(truncatedList.contains(0));
   }
+
+    // Tests merging lists together
+    @Test
+    public void mergeLists() {
+      List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
+      List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
+      List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
+      List<List<Integer>> lsts = new ArrayList<>();
+      lsts.add(list1);
+      lsts.add(list2);
+      lsts.add(list3);
+  
+      // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
+      List<Integer> result = Utility.mergeSortedLists(lsts);
+      Assert.assertNotNull(result);
+      System.out.println(result);
+      Assert.assertEquals(9, result.size());
+    }
+
+    @Test
+    public void mergeEmpty() {
+      List<Integer> list1 = new ArrayList<>();
+      List<Integer> list2 = new ArrayList<>();
+      List<List<Integer>> lsts = new ArrayList<>();
+      lsts.add(list1);
+      lsts.add(list2);
+      List<Integer> result = Utility.mergeSortedLists(lsts);
+      Assert.assertEquals(0, result.size());
+    }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -221,32 +221,32 @@ public class NodeMutationFilterTest {
     Assert.assertFalse(truncatedList.contains(0));
   }
 
-    // Tests merging lists together
-    @Test
-    public void mergeLists() {
-      List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
-      List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
-      List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
-      List<List<Integer>> lsts = new ArrayList<>();
-      lsts.add(list1);
-      lsts.add(list2);
-      lsts.add(list3);
-  
-      // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
-      List<Integer> result = Utility.mergeSortedLists(lsts);
-      Assert.assertNotNull(result);
-      System.out.println(result);
-      Assert.assertEquals(9, result.size());
-    }
+  // Tests merging lists together
+  @Test
+  public void mergeLists() {
+    List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
+    List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
+    List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
+    List<List<Integer>> lsts = new ArrayList<>();
+    lsts.add(list1);
+    lsts.add(list2);
+    lsts.add(list3);
 
-    @Test
-    public void mergeEmpty() {
-      List<Integer> list1 = new ArrayList<>();
-      List<Integer> list2 = new ArrayList<>();
-      List<List<Integer>> lsts = new ArrayList<>();
-      lsts.add(list1);
-      lsts.add(list2);
-      List<Integer> result = Utility.mergeSortedLists(lsts);
-      Assert.assertEquals(0, result.size());
-    }
+    // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
+    List<Integer> result = Utility.mergeSortedLists(lsts);
+    Assert.assertNotNull(result);
+    System.out.println(result);
+    Assert.assertEquals(9, result.size());
+  }
+
+  @Test
+  public void mergeEmpty() {
+    List<Integer> list1 = new ArrayList<>();
+    List<Integer> list2 = new ArrayList<>();
+    List<List<Integer>> lsts = new ArrayList<>();
+    lsts.add(list1);
+    lsts.add(list2);
+    List<Integer> result = Utility.mergeSortedLists(lsts);
+    Assert.assertEquals(0, result.size());
+  }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -20,13 +20,16 @@ import java.util.List;
 
 import com.proto.MutationProtos.MultiMutation;
 import com.proto.MutationProtos.Mutation;
+import com.proto.MutationProtos.TokenMutation;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test for functions within Utility that are used to filter graphs across nodes */
+/**
+ * Test for functions within Utility that are used to filter graphs across nodes
+ */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
   // lst1 contains even number of elements
@@ -35,23 +38,15 @@ public class NodeMutationFilterTest {
   List<Integer> lst2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
 
   // Following functions test the getMutationIndicesOfNode function in Utility
-  /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
+  /**
+   * Basic test for including mutliple relevant nodes for getMutationIndicesOfNode
+   */
   @Test
-  public void getMutationsOfBasic() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeC =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
+  public void getMutationsOfBasicName() {
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
+    Mutation removeAB = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").setEndNode("B")
+        .build();
+    Mutation removeC = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
@@ -71,19 +66,96 @@ public class NodeMutationFilterTest {
 
   /** Test that a null query returns an empty list */
   @Test
-  public void getMutationsOfNull() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
+  public void getMutationsOfNullName() {
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     List<MultiMutation> multiMutList = new ArrayList<>();
     multiMutList.add(addABM);
 
     List<Integer> truncatedList = Utility.getMutationIndicesOfNode(null, multiMutList);
+
+    Assert.assertNotNull(truncatedList); // Should not be null
+    Assert.assertEquals(0, truncatedList.size());
+    Assert.assertFalse(truncatedList.contains(0));
+  }
+
+  /** Multiple mutations modity a token, check to ensure they are all found */
+  @Test
+  public void getMutationsOfTokenBasic() {
+    TokenMutation tokenMut1 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("2")
+        .addTokenName("4").build();
+
+    TokenMutation tokenMut2 = TokenMutation.newBuilder().setType(TokenMutation.Type.DELETE_TOKEN).addTokenName("2")
+        .addTokenName("3").build();
+    TokenMutation tokenMut3 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("4")
+        .addTokenName("7").build();
+
+    Mutation changeToken1 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut1).build();
+    Mutation changeToken2 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut2).build();
+    Mutation changeToken3 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut3).build();
+
+    MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
+    MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
+    MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(mmChange1);
+    multiMutList.add(mmChange2);
+    multiMutList.add(mmChange3);
+
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("4", multiMutList);
+    Assert.assertEquals(2, truncatedList.size());
+    Assert.assertTrue(truncatedList.contains(0));
+    Assert.assertTrue(truncatedList.contains(2));
+    Assert.assertFalse(truncatedList.contains(1));
+  }
+
+  /** Token is not found anywhere */
+  @Test
+  public void tokenNotMutated() {
+    TokenMutation tokenMut1 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("2")
+        .addTokenName("4").build();
+
+    TokenMutation tokenMut2 = TokenMutation.newBuilder().setType(TokenMutation.Type.DELETE_TOKEN).addTokenName("2")
+        .addTokenName("3").build();
+    TokenMutation tokenMut3 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("4")
+        .addTokenName("7").build();
+
+    Mutation changeToken1 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut1).build();
+    Mutation changeToken2 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut2).build();
+    Mutation changeToken3 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
+        .setTokenChange(tokenMut3).build();
+
+    MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
+    MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
+    MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(mmChange1);
+    multiMutList.add(mmChange2);
+    multiMutList.add(mmChange3);
+
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("10", multiMutList);
+    Assert.assertEquals(0, truncatedList.size());
+    Assert.assertFalse(truncatedList.contains(0));
+    Assert.assertFalse(truncatedList.contains(2));
+    Assert.assertFalse(truncatedList.contains(1));
+  }
+
+  /** Token mutations of null return back something empty */
+  @Test
+  public void tokenMutationsOfNull() {
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
+
+    MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(addABM);
+
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken(null, multiMutList);
 
     Assert.assertNotNull(truncatedList); // Should not be null
     Assert.assertEquals(0, truncatedList.size());
@@ -122,8 +194,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * When the tgt value does exist in the middle, value found must get strictly greater (value's
-   * index is returned)
+   * When the tgt value does exist in the middle, value found must get strictly
+   * greater (value's index is returned)
    */
   @Test
   public void testInnerExistsEven() {
@@ -138,8 +210,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * When tgt value does not exist (DNE) in the list, value is just the immediate greater one. This
-   * tests a middle index is returned correctly.
+   * When tgt value does not exist (DNE) in the list, value is just the immediate
+   * greater one. This tests a middle index is returned correctly.
    */
   @Test
   public void testInnerDNEEven() {

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test for functions within Utility that are used to filter graphs across nodes */
+/**
+ * Test for functions within Utility that are used to filter graphs across nodes
+ */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
   // lst1 contains even number of elements
@@ -35,23 +37,15 @@ public class NodeMutationFilterTest {
   List<Integer> lst2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
 
   // Following functions test the getMutationIndicesOfNode function in Utility
-  /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
+  /**
+   * Basic test for including mutliple relevant nodes for getMutationIndicesOfNode
+   */
   @Test
   public void getMutationsOfBasic() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.DELETE_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
-    Mutation removeC =
-        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
+    Mutation removeAB = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").setEndNode("B")
+        .build();
+    Mutation removeC = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
@@ -72,12 +66,7 @@ public class NodeMutationFilterTest {
   /** Test that a null query returns an empty list */
   @Test
   public void getMutationsOfNull() {
-    Mutation addAB =
-        Mutation.newBuilder()
-            .setType(Mutation.Type.ADD_EDGE)
-            .setStartNode("A")
-            .setEndNode("B")
-            .build();
+    Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B").build();
 
     MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
     List<MultiMutation> multiMutList = new ArrayList<>();
@@ -122,8 +111,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * When the tgt value does exist in the middle, value found must get strictly greater (value's
-   * index is returned)
+   * When the tgt value does exist in the middle, value found must get strictly
+   * greater (value's index is returned)
    */
   @Test
   public void testInnerExistsEven() {
@@ -138,8 +127,8 @@ public class NodeMutationFilterTest {
   }
 
   /**
-   * When tgt value does not exist (DNE) in the list, value is just the immediate greater one. This
-   * tests a middle index is returned correctly.
+   * When tgt value does not exist (DNE) in the list, value is just the immediate
+   * greater one. This tests a middle index is returned correctly.
    */
   @Test
   public void testInnerDNEEven() {
@@ -177,5 +166,24 @@ public class NodeMutationFilterTest {
   public void testIsSmallestOdd() {
     int ans2 = Utility.getNextGreatestNumIndex(lst2, 0);
     Assert.assertEquals(0, ans2);
+  }
+
+  // Tests merging lists together
+  @Test
+  public void mergeLists() {
+    List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
+    List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
+    List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
+    List<List<Integer>> lsts = new ArrayList<>();
+    lsts.add(list1);
+    lsts.add(list2);
+    lsts.add(list3);
+
+    // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
+    List<Integer> result = Utility.mergeSortedLists(lsts);
+    Assert.assertNotNull(result);
+    System.out.println(result);
+    Assert.assertEquals(9, result.size());
+
   }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -15,7 +15,6 @@
 package com.google.sps;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -30,324 +30,469 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test for functions within Utility that are used to filter graphs across nodes
- */
+/** Test for functions within Utility that are used to filter graphs across nodes */
 @RunWith(JUnit4.class)
 public class NodeMutationFilterTest {
 
-    // Following functions test the getMutationIndicesOfNode function in Utility
-    /**
-     * Basic test for including mutliple relevant nodes for getMutationIndicesOfNode
-     */
-    @Test
-    public void getMutationsOfBasicName() {
-        Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B")
-                .build();
-        Mutation removeAB = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("A").setEndNode("B")
-                .build();
-        Mutation removeC = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
+  // Following functions test the getMutationIndicesOfNode function in Utility
+  /** Basic test for including mutliple relevant nodes for getMutationIndicesOfNode */
+  @Test
+  public void getMutationsOfBasicName() {
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
+    Mutation removeAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
+    Mutation removeC =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("C").build();
 
-        MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
-        MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
-        MultiMutation removeCM = MultiMutation.newBuilder().addMutation(removeC).build();
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(addABM);
-        multiMutList.add(removeABM);
-        multiMutList.add(removeCM);
+    MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
+    MultiMutation removeABM = MultiMutation.newBuilder().addMutation(removeAB).build();
+    MultiMutation removeCM = MultiMutation.newBuilder().addMutation(removeC).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(addABM);
+    multiMutList.add(removeABM);
+    multiMutList.add(removeCM);
 
-        ArrayList<Integer> truncatedList = Utility.getMutationIndicesOfNode("A", multiMutList);
+    ArrayList<Integer> truncatedList = Utility.getMutationIndicesOfNode("A", multiMutList);
 
-        Assert.assertEquals(2, truncatedList.size());
-        Assert.assertTrue(truncatedList.get(0) == 0);
-        Assert.assertTrue(truncatedList.get(1) == 1);
-    }
+    Assert.assertEquals(2, truncatedList.size());
+    Assert.assertTrue(truncatedList.get(0) == 0);
+    Assert.assertTrue(truncatedList.get(1) == 1);
+  }
 
-    /** Test that a null query returns an empty list */
-    @Test
-    public void getMutationsOfNullName() {
-        Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B")
-                .build();
+  /** Test that a null query returns an empty list */
+  @Test
+  public void getMutationsOfNullName() {
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
 
-        MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(addABM);
+    MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(addABM);
 
-        List<Integer> truncatedList = Utility.getMutationIndicesOfNode(null, multiMutList);
+    List<Integer> truncatedList = Utility.getMutationIndicesOfNode(null, multiMutList);
 
-        Assert.assertNotNull(truncatedList); // Should not be null
-        Assert.assertEquals(0, truncatedList.size());
-        Assert.assertFalse(truncatedList.contains(0));
-    }
+    Assert.assertNotNull(truncatedList); // Should not be null
+    Assert.assertEquals(0, truncatedList.size());
+    Assert.assertFalse(truncatedList.contains(0));
+  }
 
-    /** Multiple mutations modity a token, check to ensure they are all found */
-    @Test
-    public void getMutationsOfTokenBasic() {
-        TokenMutation tokenMut1 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("2")
-                .addTokenName("4").build();
+  /** Multiple mutations modity a token, check to ensure they are all found */
+  @Test
+  public void getMutationsOfTokenBasic() {
+    TokenMutation tokenMut1 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("2")
+            .addTokenName("4")
+            .build();
 
-        TokenMutation tokenMut2 = TokenMutation.newBuilder().setType(TokenMutation.Type.DELETE_TOKEN).addTokenName("2")
-                .addTokenName("3").build();
-        TokenMutation tokenMut3 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("4")
-                .addTokenName("7").build();
+    TokenMutation tokenMut2 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.DELETE_TOKEN)
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    TokenMutation tokenMut3 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("4")
+            .addTokenName("7")
+            .build();
 
-        Mutation changeToken1 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut1).build();
-        Mutation changeToken2 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut2).build();
-        Mutation changeToken3 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut3).build();
+    Mutation changeToken1 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut1)
+            .build();
+    Mutation changeToken2 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut2)
+            .build();
+    Mutation changeToken3 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut3)
+            .build();
 
-        MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
-        MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
-        MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(mmChange1);
-        multiMutList.add(mmChange2);
-        multiMutList.add(mmChange3);
+    MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
+    MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
+    MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(mmChange1);
+    multiMutList.add(mmChange2);
+    multiMutList.add(mmChange3);
 
-        List<Integer> truncatedList = Utility.getMutationIndicesOfToken("4", multiMutList);
-        Assert.assertEquals(2, truncatedList.size());
-        Assert.assertTrue(truncatedList.contains(0));
-        Assert.assertTrue(truncatedList.contains(2));
-        Assert.assertFalse(truncatedList.contains(1));
-    }
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("4", multiMutList);
+    Assert.assertEquals(2, truncatedList.size());
+    Assert.assertTrue(truncatedList.contains(0));
+    Assert.assertTrue(truncatedList.contains(2));
+    Assert.assertFalse(truncatedList.contains(1));
+  }
 
-    /** Token is not found anywhere */
-    @Test
-    public void tokenNotMutated() {
-        TokenMutation tokenMut1 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("2")
-                .addTokenName("4").build();
+  /** Token is not found anywhere */
+  @Test
+  public void tokenNotMutated() {
+    TokenMutation tokenMut1 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("2")
+            .addTokenName("4")
+            .build();
 
-        TokenMutation tokenMut2 = TokenMutation.newBuilder().setType(TokenMutation.Type.DELETE_TOKEN).addTokenName("2")
-                .addTokenName("3").build();
-        TokenMutation tokenMut3 = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("4")
-                .addTokenName("7").build();
+    TokenMutation tokenMut2 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.DELETE_TOKEN)
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    TokenMutation tokenMut3 =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("4")
+            .addTokenName("7")
+            .build();
 
-        Mutation changeToken1 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut1).build();
-        Mutation changeToken2 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut2).build();
-        Mutation changeToken3 = Mutation.newBuilder().setStartNode("A").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut3).build();
+    Mutation changeToken1 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut1)
+            .build();
+    Mutation changeToken2 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut2)
+            .build();
+    Mutation changeToken3 =
+        Mutation.newBuilder()
+            .setStartNode("A")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut3)
+            .build();
 
-        MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
-        MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
-        MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(mmChange1);
-        multiMutList.add(mmChange2);
-        multiMutList.add(mmChange3);
+    MultiMutation mmChange1 = MultiMutation.newBuilder().addMutation(changeToken1).build();
+    MultiMutation mmChange2 = MultiMutation.newBuilder().addMutation(changeToken2).build();
+    MultiMutation mmChange3 = MultiMutation.newBuilder().addMutation(changeToken3).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(mmChange1);
+    multiMutList.add(mmChange2);
+    multiMutList.add(mmChange3);
 
-        List<Integer> truncatedList = Utility.getMutationIndicesOfToken("10", multiMutList);
-        Assert.assertEquals(0, truncatedList.size());
-        Assert.assertFalse(truncatedList.contains(0));
-        Assert.assertFalse(truncatedList.contains(2));
-        Assert.assertFalse(truncatedList.contains(1));
-    }
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("10", multiMutList);
+    Assert.assertEquals(0, truncatedList.size());
+    Assert.assertFalse(truncatedList.contains(0));
+    Assert.assertFalse(truncatedList.contains(2));
+    Assert.assertFalse(truncatedList.contains(1));
+  }
 
-    /** Token mutations of null return back something empty */
-    @Test
-    public void tokenMutationsOfNull() {
-        Mutation addAB = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("A").setEndNode("B")
-                .build();
+  /** Token mutations of null return back something empty */
+  @Test
+  public void tokenMutationsOfNull() {
+    Mutation addAB =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("A")
+            .setEndNode("B")
+            .build();
 
-        MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(addABM);
+    MultiMutation addABM = MultiMutation.newBuilder().addMutation(addAB).build();
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(addABM);
 
-        List<Integer> truncatedList = Utility.getMutationIndicesOfToken(null, multiMutList);
+    List<Integer> truncatedList = Utility.getMutationIndicesOfToken(null, multiMutList);
 
-        Assert.assertNotNull(truncatedList); // Should not be null
-        Assert.assertEquals(0, truncatedList.size());
-        Assert.assertFalse(truncatedList.contains(0));
-    }
+    Assert.assertNotNull(truncatedList); // Should not be null
+    Assert.assertEquals(0, truncatedList.size());
+    Assert.assertFalse(truncatedList.contains(0));
+  }
 
-    // Tests merging lists together
-    @Test
-    public void mergeLists() {
-        List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
-        List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
-        List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
-        List<List<Integer>> lsts = new ArrayList<>();
-        lsts.add(list1);
-        lsts.add(list2);
-        lsts.add(list3);
+  // Tests merging lists together
+  @Test
+  public void mergeLists() {
+    List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
+    List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
+    List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
+    List<List<Integer>> lsts = new ArrayList<>();
+    lsts.add(list1);
+    lsts.add(list2);
+    lsts.add(list3);
 
-        // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
-        List<Integer> result = Utility.mergeSortedLists(lsts);
-        Assert.assertNotNull(result);
-        System.out.println(result);
-        Assert.assertEquals(9, result.size());
-    }
+    // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
+    List<Integer> result = Utility.mergeSortedLists(lsts);
+    Assert.assertNotNull(result);
+    System.out.println(result);
+    Assert.assertEquals(9, result.size());
+  }
 
-    @Test
-    public void mergeEmpty() {
-        List<Integer> list1 = new ArrayList<>();
-        List<Integer> list2 = new ArrayList<>();
-        List<List<Integer>> lsts = new ArrayList<>();
-        lsts.add(list1);
-        lsts.add(list2);
-        List<Integer> result = Utility.mergeSortedLists(lsts);
-        Assert.assertEquals(0, result.size());
-    }
+  @Test
+  public void mergeEmpty() {
+    List<Integer> list1 = new ArrayList<>();
+    List<Integer> list2 = new ArrayList<>();
+    List<List<Integer>> lsts = new ArrayList<>();
+    lsts.add(list1);
+    lsts.add(list2);
+    List<Integer> result = Utility.mergeSortedLists(lsts);
+    Assert.assertEquals(0, result.size());
+  }
 
-    /**
-     * Getting mutation indices of multiple nodes returns the union of all their
-     * individual indices in sorted order
-     */
-    @Test
-    public void getMutationsOfMultiple() {
-        Mutation removeEF = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("E").setEndNode("F")
-                .build();
-        Mutation removeF = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+  /**
+   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
+   * sorted order
+   */
+  @Test
+  public void getMutationsOfMultiple() {
+    Mutation removeEF =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("E")
+            .setEndNode("F")
+            .build();
+    Mutation removeF =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
 
-        Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-        Mutation addEG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("E").setEndNode("G")
-                .build();
+    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
+    Mutation addEG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("E")
+            .setEndNode("G")
+            .build();
 
-        Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-        Mutation addHG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("H").setEndNode("G")
-                .build();
+    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
+    Mutation addHG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("H")
+            .setEndNode("G")
+            .build();
 
-        Mutation addDG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("D").setEndNode("G")
-                .build();
+    Mutation addDG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("D")
+            .setEndNode("G")
+            .build();
 
-        TokenMutation tokenMut = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("1")
-                .addTokenName("2").addTokenName("3").build();
-        Mutation addTokenToB = Mutation.newBuilder().setStartNode("B").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut).build();
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    Mutation addTokenToB =
+        Mutation.newBuilder()
+            .setStartNode("B")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
-        MultiMutation removeFM = MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-        MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-        MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-        MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-        MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
+    MultiMutation removeFM =
+        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
+    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
+    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
+    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
 
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(removeFM);
-        multiMutList.add(addGM);
-        multiMutList.add(addHM);
-        multiMutList.add(addDGM);
-        multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(removeFM);
+    multiMutList.add(addGM);
+    multiMutList.add(addHM);
+    multiMutList.add(addDGM);
+    multiMutList.add(addTokenToBM);
 
-        HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
-        Set<String> nodeNames = new HashSet<>();
-        nodeNames.add("A");
-        nodeNames.add("B");
-        nodeNames.add("D");
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+    nodeNames.add("A");
+    nodeNames.add("B");
+    nodeNames.add("D");
 
-        List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
-        Assert.assertEquals(2, truncatedList.size());
-        Assert.assertTrue(truncatedList.get(0) == 3);
-        Assert.assertTrue(truncatedList.get(1) == 4);
-    }
+    Assert.assertEquals(2, truncatedList.size());
+    Assert.assertTrue(truncatedList.get(0) == 3);
+    Assert.assertTrue(truncatedList.get(1) == 4);
+  }
 
-    /**
-     * Getting mutation indices of multiple nodes returns the union of all their
-     * individual indices in sorted order without duplicates
-     */
-    @Test
-    public void getMutationsOfMultipleNoDuplicates() {
-        Mutation removeEF = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("E").setEndNode("F")
-                .build();
-        Mutation removeF = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+  /**
+   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
+   * sorted order without duplicates
+   */
+  @Test
+  public void getMutationsOfMultipleNoDuplicates() {
+    Mutation removeEF =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("E")
+            .setEndNode("F")
+            .build();
+    Mutation removeF =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
 
-        Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-        Mutation addEG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("E").setEndNode("G")
-                .build();
+    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
+    Mutation addEG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("E")
+            .setEndNode("G")
+            .build();
 
-        Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-        Mutation addHG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("H").setEndNode("G")
-                .build();
+    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
+    Mutation addHG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("H")
+            .setEndNode("G")
+            .build();
 
-        Mutation addDG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("D").setEndNode("G")
-                .build();
+    Mutation addDG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("D")
+            .setEndNode("G")
+            .build();
 
-        TokenMutation tokenMut = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("1")
-                .addTokenName("2").addTokenName("3").build();
-        Mutation addTokenToB = Mutation.newBuilder().setStartNode("B").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut).build();
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    Mutation addTokenToB =
+        Mutation.newBuilder()
+            .setStartNode("B")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
-        MultiMutation removeFM = MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-        MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-        MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-        MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-        MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
+    MultiMutation removeFM =
+        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
+    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
+    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
+    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
 
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(removeFM);
-        multiMutList.add(addGM);
-        multiMutList.add(addHM);
-        multiMutList.add(addDGM);
-        multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(removeFM);
+    multiMutList.add(addGM);
+    multiMutList.add(addHM);
+    multiMutList.add(addDGM);
+    multiMutList.add(addTokenToBM);
 
-        HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
-        Set<String> nodeNames = new HashSet<>();
-        nodeNames.add("G");
-        nodeNames.add("E");
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+    nodeNames.add("G");
+    nodeNames.add("E");
 
-        List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
-        Assert.assertEquals(4, truncatedList.size());
-        Assert.assertTrue(truncatedList.get(0) == 0);
-        Assert.assertTrue(truncatedList.get(1) == 1);
-        Assert.assertTrue(truncatedList.get(2) == 2);
-        Assert.assertTrue(truncatedList.get(3) == 3);
-    }
+    Assert.assertEquals(4, truncatedList.size());
+    Assert.assertTrue(truncatedList.get(0) == 0);
+    Assert.assertTrue(truncatedList.get(1) == 1);
+    Assert.assertTrue(truncatedList.get(2) == 2);
+    Assert.assertTrue(truncatedList.get(3) == 3);
+  }
 
-    /**
-     * Getting mutation indices of multiple nodes returns the union of all their
-     * individual indices in sorted order without duplicates, ignoring empty strings
-     */
-    @Test
-    public void getMutationsOfMultipleIgnoreEmpty() {
-        Mutation removeEF = Mutation.newBuilder().setType(Mutation.Type.DELETE_EDGE).setStartNode("E").setEndNode("F")
-                .build();
-        Mutation removeF = Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
+  /**
+   * Getting mutation indices of multiple nodes returns the union of all their individual indices in
+   * sorted order without duplicates, ignoring empty strings
+   */
+  @Test
+  public void getMutationsOfMultipleIgnoreEmpty() {
+    Mutation removeEF =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.DELETE_EDGE)
+            .setStartNode("E")
+            .setEndNode("F")
+            .build();
+    Mutation removeF =
+        Mutation.newBuilder().setType(Mutation.Type.DELETE_NODE).setStartNode("F").build();
 
-        Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
-        Mutation addEG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("E").setEndNode("G")
-                .build();
+    Mutation addG = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("G").build();
+    Mutation addEG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("E")
+            .setEndNode("G")
+            .build();
 
-        Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
-        Mutation addHG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("H").setEndNode("G")
-                .build();
+    Mutation addH = Mutation.newBuilder().setType(Mutation.Type.ADD_NODE).setStartNode("H").build();
+    Mutation addHG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("H")
+            .setEndNode("G")
+            .build();
 
-        Mutation addDG = Mutation.newBuilder().setType(Mutation.Type.ADD_EDGE).setStartNode("D").setEndNode("G")
-                .build();
+    Mutation addDG =
+        Mutation.newBuilder()
+            .setType(Mutation.Type.ADD_EDGE)
+            .setStartNode("D")
+            .setEndNode("G")
+            .build();
 
-        TokenMutation tokenMut = TokenMutation.newBuilder().setType(TokenMutation.Type.ADD_TOKEN).addTokenName("1")
-                .addTokenName("2").addTokenName("3").build();
-        Mutation addTokenToB = Mutation.newBuilder().setStartNode("B").setType(Mutation.Type.CHANGE_TOKEN)
-                .setTokenChange(tokenMut).build();
+    TokenMutation tokenMut =
+        TokenMutation.newBuilder()
+            .setType(TokenMutation.Type.ADD_TOKEN)
+            .addTokenName("1")
+            .addTokenName("2")
+            .addTokenName("3")
+            .build();
+    Mutation addTokenToB =
+        Mutation.newBuilder()
+            .setStartNode("B")
+            .setType(Mutation.Type.CHANGE_TOKEN)
+            .setTokenChange(tokenMut)
+            .build();
 
-        MultiMutation removeFM = MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
-        MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
-        MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
-        MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
-        MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
+    MultiMutation removeFM =
+        MultiMutation.newBuilder().addMutation(removeEF).addMutation(removeF).build();
+    MultiMutation addGM = MultiMutation.newBuilder().addMutation(addG).addMutation(addEG).build();
+    MultiMutation addHM = MultiMutation.newBuilder().addMutation(addH).addMutation(addHG).build();
+    MultiMutation addDGM = MultiMutation.newBuilder().addMutation(addDG).build();
+    MultiMutation addTokenToBM = MultiMutation.newBuilder().addMutation(addTokenToB).build();
 
-        List<MultiMutation> multiMutList = new ArrayList<>();
-        multiMutList.add(removeFM);
-        multiMutList.add(addGM);
-        multiMutList.add(addHM);
-        multiMutList.add(addDGM);
-        multiMutList.add(addTokenToBM);
+    List<MultiMutation> multiMutList = new ArrayList<>();
+    multiMutList.add(removeFM);
+    multiMutList.add(addGM);
+    multiMutList.add(addHM);
+    multiMutList.add(addDGM);
+    multiMutList.add(addTokenToBM);
 
-        HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
-        Set<String> nodeNames = new HashSet<>();
-        nodeNames.add("G");
-        nodeNames.add("E");
-        nodeNames.add("");
+    HashMap<String, List<Integer>> mutationIndicesMap = new HashMap<>();
+    Set<String> nodeNames = new HashSet<>();
+    nodeNames.add("G");
+    nodeNames.add("E");
+    nodeNames.add("");
 
-        List<Integer> truncatedList = Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
+    List<Integer> truncatedList =
+        Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
-        Assert.assertEquals(4, truncatedList.size());
-        Assert.assertTrue(truncatedList.get(0) == 0);
-        Assert.assertTrue(truncatedList.get(1) == 1);
-        Assert.assertTrue(truncatedList.get(2) == 2);
-        Assert.assertTrue(truncatedList.get(3) == 3);
-    }
+    Assert.assertEquals(4, truncatedList.size());
+    Assert.assertTrue(truncatedList.get(0) == 0);
+    Assert.assertTrue(truncatedList.get(1) == 1);
+    Assert.assertTrue(truncatedList.get(2) == 2);
+    Assert.assertTrue(truncatedList.get(3) == 3);
+  }
 }

--- a/src/main/java/com/google/sps/NodeMutationFilterTest.java
+++ b/src/main/java/com/google/sps/NodeMutationFilterTest.java
@@ -139,7 +139,7 @@ public class NodeMutationFilterTest {
     multiMutList.add(mmChange2);
     multiMutList.add(mmChange3);
 
-    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("4", multiMutList);
+    Set<Integer> truncatedList = Utility.getMutationIndicesOfToken("4", multiMutList);
     Assert.assertEquals(2, truncatedList.size());
     Assert.assertTrue(truncatedList.contains(0));
     Assert.assertTrue(truncatedList.contains(2));
@@ -196,7 +196,7 @@ public class NodeMutationFilterTest {
     multiMutList.add(mmChange2);
     multiMutList.add(mmChange3);
 
-    List<Integer> truncatedList = Utility.getMutationIndicesOfToken("10", multiMutList);
+    Set<Integer> truncatedList = Utility.getMutationIndicesOfToken("10", multiMutList);
     Assert.assertEquals(0, truncatedList.size());
     Assert.assertFalse(truncatedList.contains(0));
     Assert.assertFalse(truncatedList.contains(2));
@@ -217,40 +217,11 @@ public class NodeMutationFilterTest {
     List<MultiMutation> multiMutList = new ArrayList<>();
     multiMutList.add(addABM);
 
-    List<Integer> truncatedList = Utility.getMutationIndicesOfToken(null, multiMutList);
+    Set<Integer> truncatedList = Utility.getMutationIndicesOfToken(null, multiMutList);
 
     Assert.assertNotNull(truncatedList); // Should not be null
     Assert.assertEquals(0, truncatedList.size());
     Assert.assertFalse(truncatedList.contains(0));
-  }
-
-  // Tests merging lists together
-  @Test
-  public void mergeLists() {
-    List<Integer> list1 = new ArrayList<>(Arrays.asList(1, 4, 7, 15));
-    List<Integer> list2 = new ArrayList<>(Arrays.asList(4, 7, 12, 13, 15));
-    List<Integer> list3 = new ArrayList<>(Arrays.asList(0, 6, 9));
-    List<List<Integer>> lsts = new ArrayList<>();
-    lsts.add(list1);
-    lsts.add(list2);
-    lsts.add(list3);
-
-    // should be 0, 1, 4, 6, 7, 9, 12, 13, 15
-    List<Integer> result = Utility.mergeSortedLists(lsts);
-    Assert.assertNotNull(result);
-    System.out.println(result);
-    Assert.assertEquals(9, result.size());
-  }
-
-  @Test
-  public void mergeEmpty() {
-    List<Integer> list1 = new ArrayList<>();
-    List<Integer> list2 = new ArrayList<>();
-    List<List<Integer>> lsts = new ArrayList<>();
-    lsts.add(list1);
-    lsts.add(list2);
-    List<Integer> result = Utility.mergeSortedLists(lsts);
-    Assert.assertEquals(0, result.size());
   }
 
   /**
@@ -325,12 +296,12 @@ public class NodeMutationFilterTest {
     nodeNames.add("B");
     nodeNames.add("D");
 
-    List<Integer> truncatedList =
+    Set<Integer> truncatedList =
         Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(2, truncatedList.size());
-    Assert.assertTrue(truncatedList.get(0) == 3);
-    Assert.assertTrue(truncatedList.get(1) == 4);
+    Assert.assertTrue(truncatedList.contains(3));
+    Assert.assertTrue(truncatedList.contains(4));
   }
 
   /**
@@ -404,14 +375,14 @@ public class NodeMutationFilterTest {
     nodeNames.add("G");
     nodeNames.add("E");
 
-    List<Integer> truncatedList =
+    Set<Integer> truncatedList =
         Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
-    Assert.assertTrue(truncatedList.get(0) == 0);
-    Assert.assertTrue(truncatedList.get(1) == 1);
-    Assert.assertTrue(truncatedList.get(2) == 2);
-    Assert.assertTrue(truncatedList.get(3) == 3);
+    Assert.assertTrue(truncatedList.contains(0));
+    Assert.assertTrue(truncatedList.contains(1));
+    Assert.assertTrue(truncatedList.contains(2));
+    Assert.assertTrue(truncatedList.contains(3));
   }
 
   /**
@@ -486,13 +457,13 @@ public class NodeMutationFilterTest {
     nodeNames.add("E");
     nodeNames.add("");
 
-    List<Integer> truncatedList =
+    Set<Integer> truncatedList =
         Utility.findRelevantMutations(nodeNames, mutationIndicesMap, multiMutList);
 
     Assert.assertEquals(4, truncatedList.size());
-    Assert.assertTrue(truncatedList.get(0) == 0);
-    Assert.assertTrue(truncatedList.get(1) == 1);
-    Assert.assertTrue(truncatedList.get(2) == 2);
-    Assert.assertTrue(truncatedList.get(3) == 3);
+    Assert.assertTrue(truncatedList.contains(0));
+    Assert.assertTrue(truncatedList.contains(1));
+    Assert.assertTrue(truncatedList.contains(2));
+    Assert.assertTrue(truncatedList.contains(3));
   }
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -125,7 +125,6 @@ public final class Utility {
     } else if (mutationNum > multiMutList.size()) {
       mutationNum = multiMutList.size() - 1;
     }
-
     if (curr.numMutations() <= mutationNum) { // going forward
       for (int i = curr.numMutations() + 1; i <= mutationNum; i++) {
         // Mutate graph operates in place
@@ -158,7 +157,7 @@ public final class Utility {
           originalCopy.graphNodesMap(),
           originalCopy.roots(),
           mutationNum,
-          original.tokenMap());
+          originalCopy.tokenMap());
     }
   }
 
@@ -435,7 +434,6 @@ public final class Utility {
         mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
       }
       relevantIndices.addAll(mutationIndicesMap.get(nodeName));
-      // System.out.println(relevantIndices);
     }
     ArrayList<Integer> result = new ArrayList<>(relevantIndices);
     Collections.sort(result);
@@ -457,7 +455,6 @@ public final class Utility {
         mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
       }
       relevantIndices.addAll(mutationIndicesMap.get(nodeName));
-      // System.out.println(relevantIndices);
     }
     return relevantIndices;
   }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -417,5 +417,5 @@ public final class Utility {
     ArrayList<Integer> result = new ArrayList<>(relevantIndices);
     Collections.sort(result);
     return result;
-  } 
+  }
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -207,50 +207,6 @@ public final class Utility {
   }
 
   /**
-   * Returns a list of the indices of the mutations in origList that mutate
-   *
-   * @param nodeName the name of the node to filter
-   * @param origList the original list of mutations
-   * @param tokenName paramter for token name. list ends when that token is deleted
-   * @return a list of indices that are relevant to the node, truncated at the point a given token
-   *     is deleted
-   */
-  public static ArrayList<Integer> getMutationIndicesOfNode(
-      String nodeName, List<MultiMutation> origList, String tokenNameSearched) {
-    ArrayList<Integer> lst = new ArrayList<>();
-    // Shouldn't happen, but in case the nodeName is null an empty list is returned
-    if (nodeName == null) {
-      return lst;
-    }
-    for (int i = 0; i < origList.size(); i++) {
-      MultiMutation multiMut = origList.get(i);
-      List<Mutation> mutList = multiMut.getMutationList();
-      for (Mutation mut : mutList) {
-        String startName = mut.getStartNode();
-        String endName = mut.getEndNode();
-        if (nodeName.equals(startName) || nodeName.equals(endName)) {
-          lst.add(i);
-          // If the mutation is a delete token AND the token passed in as param is
-          // deleted, then we want no more
-          if (tokenNameSearched.length() != 0 && mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
-            TokenMutation tokenMut = mut.getTokenChange();
-            TokenMutation.Type tokenMutType = tokenMut.getType();
-            if (tokenMutType == TokenMutation.Type.DELETE_TOKEN) {
-              List<String> tokenNames = tokenMut.getTokenNameList();
-              if (tokenNames.contains(tokenNameSearched)) {
-                return lst;
-              }
-            }
-          }
-
-          break;
-        }
-      }
-    }
-    return lst;
-  }
-
-  /**
    * Returns a set of indices on the original list that related to a given token
    *
    * @param tokenName the token name to search for

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -251,7 +251,7 @@ public final class Utility {
   }
 
   /**
-   * Returns a set of indices on the original list that related to a given node
+   * Returns a set of indices on the original list that related to a given token
    *
    * @param tokenName the token name to search for
    * @param origList the original list of mutations
@@ -268,8 +268,7 @@ public final class Utility {
       List<Mutation> mutList = multiMut.getMutationList();
       for (Mutation mut : mutList) {
         if (mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
-          TokenMutation tokenMut = mut.getTokenChange();
-          List<String> tokenNames = tokenMut.getTokenNameList();
+          List<String> tokenNames = mut.getTokenChange().getTokenNameList();
           if (tokenNames.contains(tokenName)) {
             lst.add(i);
             break;
@@ -322,8 +321,8 @@ public final class Utility {
 
   /**
    * Given a list of node names, a map from node name to mutation indices of that node and a list of
-   * multimutations applied to all nodes, returns a list of indices of multimutations in which any
-   * of the nodes in nodeNames get mutated (returned in sorted order)
+   * multimutations applied to all nodes, returns a set of indices of multimutations in which any
+   * of the nodes in nodeNames get mutated
    *
    * @param nodeNames the names of nodes to restrict the returned list of mutations to
    * @param mutationIndicesMap a map from node name -> indices of mutations that mutate it

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -284,7 +284,7 @@ public final class Utility {
   public static Set<Integer> getMutationIndicesOfTokenSet(
       String tokenName, List<MultiMutation> origList) {
     Set<Integer> lst = new HashSet<>();
-    if (tokenName == null) {
+    if (tokenName == null || tokenName.length() == 0) {
       return lst;
     }
     for (int i = 0; i < origList.size(); i++) {

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -16,7 +16,6 @@ package com.google.sps;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -251,36 +250,13 @@ public final class Utility {
   }
 
   /**
-   * Returns a list of indices on the original list that related to a given node
+   * Returns a set of indices on the original list that related to a given node
    *
    * @param tokenName the token name to search for
    * @param origList the original list of mutations
-   * @return a list of indices, empty if tokenName is null or if token is not changed
+   * @return a set of indices, empty if tokenName is null or if token is not changed
    */
-  public static ArrayList<Integer> getMutationIndicesOfToken(
-      String tokenName, List<MultiMutation> origList) {
-    ArrayList<Integer> lst = new ArrayList<>();
-    if (tokenName == null) {
-      return lst;
-    }
-    for (int i = 0; i < origList.size(); i++) {
-      MultiMutation multiMut = origList.get(i);
-      List<Mutation> mutList = multiMut.getMutationList();
-      for (Mutation mut : mutList) {
-        if (mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
-          TokenMutation tokenMut = mut.getTokenChange();
-          List<String> tokenNames = tokenMut.getTokenNameList();
-          if (tokenNames.contains(tokenName)) {
-            lst.add(i);
-            break;
-          }
-        }
-      }
-    }
-    return lst;
-  }
-
-  public static Set<Integer> getMutationIndicesOfTokenSet(
+  public static Set<Integer> getMutationIndicesOfToken(
       String tokenName, List<MultiMutation> origList) {
     Set<Integer> lst = new HashSet<>();
     if (tokenName == null || tokenName.length() == 0) {
@@ -302,6 +278,7 @@ public final class Utility {
     }
     return lst;
   }
+
   /**
    * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
    * contained in the graph
@@ -311,71 +288,6 @@ public final class Utility {
    */
   public static Set<String> getNodeNamesInGraph(MutableGraph<GraphNode> graph) {
     return graph.nodes().stream().map(node -> node.name()).collect(Collectors.toSet());
-  }
-
-  public static List<Integer> mergeSortedLists(List<List<Integer>> sortedLists) {
-    int numLists = sortedLists.size();
-    if (sortedLists.size() == 0) return new ArrayList<>();
-    else if (sortedLists.size() == 1) {
-      return sortedLists.get(0);
-    } else {
-      int left = numLists / 2;
-      return mergeTwoLists(
-          mergeSortedLists(new ArrayList<>(sortedLists.subList(0, left))),
-          mergeSortedLists(new ArrayList<>(sortedLists.subList(left, sortedLists.size()))));
-    }
-
-    // We merge two lists at a time until we get one list remaining
-    // while (numLists != 1) {
-    // int low = 0;
-    // int high = numLists - 1;
-    // while (low < high) {
-    // // System.out.println(mergeTwoLists(sortedLists.get(low),
-    // sortedLists.get(high)));
-    // System.out.println(sortedLists);
-    // sortedLists.set(low, mergeTwoLists(sortedLists.get(low),
-    // sortedLists.get(high)));
-    // low++;
-    // high--;
-    // }
-    // numLists = high + 1;
-    // }
-    // return sortedLists.get(0);
-  }
-
-  public static List<Integer> mergeTwoLists(List<Integer> l1, List<Integer> l2) {
-    ArrayList<Integer> result = new ArrayList<>();
-    int pointer1 = 0;
-    int pointer2 = 0;
-
-    while (pointer1 < l1.size() && pointer2 < l2.size()) {
-      int smallest;
-      if (l1.get(pointer1) <= l2.get(pointer2)) {
-        smallest = l1.get(pointer1);
-        pointer1++;
-      } else {
-        smallest = l2.get(pointer2);
-        pointer2++;
-      }
-      // no duplicates
-      if (result.size() == 0 || result.get(result.size() - 1) != smallest) {
-        result.add(smallest);
-      }
-    }
-    // Check individual, if the other has reached the bounds
-    while (pointer1 < l1.size()) {
-      if (result.size() == 0 || result.get(result.size() - 1) != l1.get(pointer1)) {
-        result.add(l1.get(pointer1));
-      }
-      pointer1++;
-    }
-    while (pointer2 < l2.size()) {
-      if (result.size() == 0 || result.get(result.size() - 1) != l2.get(pointer2)) {
-        result.add(l2.get(pointer2));
-      }
-      pointer2++;
-    }
-    return result;
   }
 
   /**
@@ -415,32 +327,11 @@ public final class Utility {
    * @param nodeNames the names of nodes to restrict the returned list of mutations to
    * @param mutationIndicesMap a map from node name -> indices of mutations that mutate it
    * @param multiMutList a list of multimutations which mutationIndices map indexes into
-   * @return a list of indices in multiMutList at which any of the nodes in nodeNames are mutated
+   * @return a set of indices in multiMutList at which any of the nodes in nodeNames are mutated
    *     Might modify mutationIndices map by caching information about relevant mutation indices of
    *     some nodes
    */
-  public static List<Integer> findRelevantMutations(
-      Set<String> nodeNames,
-      Map<String, List<Integer>> mutationIndicesMap,
-      List<MultiMutation> multiMutList) {
-    Set<Integer> relevantIndices = new HashSet<>();
-    for (String nodeName : nodeNames) {
-      // No node name should be an empty string
-      if (nodeName.equals("")) {
-        continue;
-      }
-      // Find or compute and cache the relevant mutation indices for each node
-      if (!mutationIndicesMap.containsKey(nodeName)) {
-        mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
-      }
-      relevantIndices.addAll(mutationIndicesMap.get(nodeName));
-    }
-    ArrayList<Integer> result = new ArrayList<>(relevantIndices);
-    Collections.sort(result);
-    return result;
-  }
-
-  public static Set<Integer> findRelevantMutationsSet(
+  public static Set<Integer> findRelevantMutations(
       Set<String> nodeNames,
       Map<String, List<Integer>> mutationIndicesMap,
       List<MultiMutation> multiMutList) {

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -281,6 +281,28 @@ public final class Utility {
     return lst;
   }
 
+  public static Set<Integer> getMutationIndicesOfTokenSet(
+    String tokenName, List<MultiMutation> origList) {
+  Set<Integer> lst = new HashSet<>();
+  if (tokenName == null) {
+    return lst;
+  }
+  for (int i = 0; i < origList.size(); i++) {
+    MultiMutation multiMut = origList.get(i);
+    List<Mutation> mutList = multiMut.getMutationList();
+    for (Mutation mut : mutList) {
+      if (mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
+        TokenMutation tokenMut = mut.getTokenChange();
+        List<String> tokenNames = tokenMut.getTokenNameList();
+        if (tokenNames.contains(tokenName)) {
+          lst.add(i);
+          break;
+        }
+      }
+    }
+  }
+  return lst;
+}
   /**
    * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
    * contained in the graph

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -64,7 +64,7 @@ public final class Utility {
    * @param mutationIndices the indices in the entire mutation list that mutate the relevant nodes
    * @param mutDiff the difference between the current graph and the requested graph
    * @param maxNumber the total number of mutations, without filtering
-   * @param queried a list of node names the client had requested
+   * @param queried a set of node names the client had requested
    * @return a JSON object containing as entries the nodes and edges of this graph as well as the
    *     length of the list of mutations this graph is an intermediate result of applying, the
    *     indices at which relevant nodes are mutated and the change made to relevant nodes to obtain

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -186,6 +186,12 @@ public final class Utility {
     return lst;
   }
 
+  /**
+   * Returns a list of indices on the original list that related to a given node
+   * @param tokenName the token name to search for
+   * @param origList the original list of mutations
+   * @return a list of indices, empty if tokenName is null or if token is not changed
+   */
   public static ArrayList<Integer> getMutationIndicesOfToken(
       String tokenName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
@@ -196,7 +202,7 @@ public final class Utility {
       MultiMutation multiMut = origList.get(i);
       List<Mutation> mutList = multiMut.getMutationList();
       for (Mutation mut : mutList) {
-        if (mut.getType().equals(CHANGE_TOKEN)) {
+        if (mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
           TokenMutation tokenMut = mut.getTokenChange();
           List<String> tokenNames = tokenMut.getTokenNameList();
           if (tokenNames.contains(tokenName)) {

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -32,7 +32,6 @@ import com.google.protobuf.Struct;
 import com.proto.GraphProtos.Node;
 import com.proto.MutationProtos.MultiMutation;
 import com.proto.MutationProtos.Mutation;
-import com.proto.MutationProtos.TokenMutation;
 
 import org.json.JSONObject;
 

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -216,7 +216,6 @@ public final class Utility {
     return lst;
   }
 
-
   /**
    * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
    * contained in the graph

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -75,11 +75,11 @@ public final class Utility {
       List<Integer> mutationIndices,
       MultiMutation mutDiff,
       int maxNumber,
-      List<String> queried) {
+      HashSet<String> queried) {
     Type typeOfNode = new TypeToken<Set<GraphNode>>() {}.getType();
     Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {}.getType();
     Type typeOfIndices = new TypeToken<List<Integer>>() {}.getType();
-    Type typeOfQueried = new TypeToken<List<String>>() {}.getType();
+    Type typeOfQueried = new TypeToken<Set<String>>() {}.getType();
     Gson gson = new Gson();
     String nodeJson = gson.toJson(graph.nodes(), typeOfNode);
     String edgeJson = gson.toJson(graph.edges(), typeOfEdge);
@@ -417,5 +417,5 @@ public final class Utility {
     ArrayList<Integer> result = new ArrayList<>(relevantIndices);
     Collections.sort(result);
     return result;
-  }
+  } 
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -29,6 +29,7 @@ import com.google.protobuf.Struct;
 import com.proto.GraphProtos.Node;
 import com.proto.MutationProtos.MultiMutation;
 import com.proto.MutationProtos.Mutation;
+import com.proto.MutationProtos.TokenMutation;
 
 import org.json.JSONObject;
 
@@ -183,6 +184,28 @@ public final class Utility {
       }
     }
     return lst;
+  }
+
+  public static ArrayList<Integer> getMutationIndicesOfToken(String tokenName, List<MultiMutation> origList) {
+    ArrayList<Integer> lst = new ArrayList<>();
+    if (tokenName == null) {
+      return lst;
+    }
+    for (int i = 0; i < origList.size(); i++) {
+      MultiMutation multiMut = origList.get(i);
+      List<Mutation> mutList = multiMut.getMutationList();
+      for (Mutation mut : mutList) {
+        if (mut.getType().equals(CHANGE_TOKEN)) {
+          TokenMutation tokenMut = mut.getTokenChange();
+          List<String> tokenNames = tokenMut.getTokenNameList();
+          if (tokenNames.contains(tokenName)) {
+            lst.add(i);
+            break;
+          }
+        }
+      }
+    }
+    return lst; 
   }
 
   /**

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -413,9 +413,30 @@ public final class Utility {
         mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
       }
       relevantIndices.addAll(mutationIndicesMap.get(nodeName));
+      // System.out.println(relevantIndices);
     }
     ArrayList<Integer> result = new ArrayList<>(relevantIndices);
     Collections.sort(result);
     return result;
+  }
+
+  public static Set<Integer> findRelevantMutationsSet(
+      Set<String> nodeNames,
+      Map<String, List<Integer>> mutationIndicesMap,
+      List<MultiMutation> multiMutList) {
+    Set<Integer> relevantIndices = new HashSet<>();
+    for (String nodeName : nodeNames) {
+      // No node name should be an empty string
+      if (nodeName.equals("")) {
+        continue;
+      }
+      // Find or compute and cache the relevant mutation indices for each node
+      if (!mutationIndicesMap.containsKey(nodeName)) {
+        mutationIndicesMap.put(nodeName, getMutationIndicesOfNode(nodeName, multiMutList));
+      }
+      relevantIndices.addAll(mutationIndicesMap.get(nodeName));
+      // System.out.println(relevantIndices);
+    }
+    return relevantIndices;
   }
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -226,7 +226,7 @@ public final class Utility {
 
   public static List<Integer> mergeSortedLists(List<List<Integer>> sortedLists) {
     int numLists = sortedLists.size();
-    if (sortedLists.size() == 0) return null;
+    if (sortedLists.size() == 0) return new ArrayList<>();
     else if (sortedLists.size() == 1) {
       return sortedLists.get(0);
     } else {
@@ -255,8 +255,6 @@ public final class Utility {
   }
 
   public static List<Integer> mergeTwoLists(List<Integer> l1, List<Integer> l2) {
-    System.out.println(l1);
-    System.out.println(l2);
     ArrayList<Integer> result = new ArrayList<>();
     int pointer1 = 0;
     int pointer2 = 0;
@@ -275,11 +273,8 @@ public final class Utility {
         result.add(smallest);
       }
     }
-    System.out.println(pointer1);
-    System.out.println(pointer2);
     // Check individual, if the other has reached the bounds
     while (pointer1 < l1.size()) {
-      System.out.println("hello");
       if (result.size() == 0 || result.get(result.size() - 1) != l1.get(pointer1)) {
         result.add(l1.get(pointer1));
       }
@@ -291,7 +286,6 @@ public final class Utility {
       }
       pointer2++;
     }
-    System.out.println(result);
     return result;
   }
 

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -186,7 +186,8 @@ public final class Utility {
     return lst;
   }
 
-  public static ArrayList<Integer> getMutationIndicesOfToken(String tokenName, List<MultiMutation> origList) {
+  public static ArrayList<Integer> getMutationIndicesOfToken(
+      String tokenName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
     if (tokenName == null) {
       return lst;
@@ -205,7 +206,7 @@ public final class Utility {
         }
       }
     }
-    return lst; 
+    return lst;
   }
 
   /**

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,8 +40,8 @@ public final class Utility {
   }
 
   /**
-   * Converts a proto node object into a graph node object that does not store the names of the
-   * child nodes but may store additional information.
+   * Converts a proto node object into a graph node object that does not store the
+   * names of the child nodes but may store additional information.
    *
    * @param thisNode the input data Node object
    * @return a useful node used to construct the Guava Graph
@@ -53,50 +54,47 @@ public final class Utility {
   }
 
   /**
-   * Converts a Guava graph into a String encoding of a JSON Object. The object contains nodes and
-   * edges of the graph.
+   * Converts a Guava graph into a String encoding of a JSON Object. The object
+   * contains nodes and edges of the graph.
    *
-   * @param graph the graph to convert into a JSON String
+   * @param graph        the graph to convert into a JSON String
    * @param maxMutations the length of the list of mutations
-   * @param mutDiff the difference between the current graph and the requested graph
-   * @return a JSON object containing as entries the nodes and edges of this graph as well as the
-   *     length of the list of mutations this graph is an intermediate result of applying
+   * @param mutDiff      the difference between the current graph and the
+   *                     requested graph
+   * @return a JSON object containing as entries the nodes and edges of this graph
+   *         as well as the length of the list of mutations this graph is an
+   *         intermediate result of applying
    */
-  public static String graphToJson(
-      MutableGraph<GraphNode> graph, List<Integer> mutationIndices, MultiMutation mutDiff) {
-    Type typeOfNode = new TypeToken<Set<GraphNode>>() {}.getType();
-    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {}.getType();
-    Type typeOfIndices = new TypeToken<List<Integer>>() {}.getType();
+  public static String graphToJson(MutableGraph<GraphNode> graph, List<Integer> mutationIndices,
+      MultiMutation mutDiff) {
+    Type typeOfNode = new TypeToken<Set<GraphNode>>() {
+    }.getType();
+    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {
+    }.getType();
+    Type typeOfIndices = new TypeToken<List<Integer>>() {
+    }.getType();
     Gson gson = new Gson();
     String nodeJson = gson.toJson(graph.nodes(), typeOfNode);
     String edgeJson = gson.toJson(graph.edges(), typeOfEdge);
-    String mutDiffJson =
-        (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
+    String mutDiffJson = (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
     String reason = (mutDiff == null || !mutDiff.isInitialized()) ? "" : mutDiff.getReason();
     String mutationIndicesJson = gson.toJson(mutationIndices, typeOfIndices);
-    String resultJson =
-        new JSONObject()
-            .put("nodes", nodeJson)
-            .put("edges", edgeJson)
-            .put("mutationDiff", mutDiffJson)
-            .put("reason", reason)
-            .put("mutationIndices", mutationIndicesJson)
-            .toString();
+    String resultJson = new JSONObject().put("nodes", nodeJson).put("edges", edgeJson).put("mutationDiff", mutDiffJson)
+        .put("reason", reason).put("mutationIndices", mutationIndicesJson).toString();
     return resultJson;
   }
 
   /**
-   * @param original the original graph
-   * @param curr the current (most recently-requested) graph (requires that original != curr)
-   * @param mutationNum number of mutations to apply
+   * @param original     the original graph
+   * @param curr         the current (most recently-requested) graph (requires
+   *                     that original != curr)
+   * @param mutationNum  number of mutations to apply
    * @param multiMutList multi-mutation list
    * @return the resulting data graph or null if there was an error
    */
-  public static DataGraph getGraphAtMutationNumber(
-      DataGraph original, DataGraph curr, int mutationNum, List<MultiMutation> multiMutList)
-      throws IllegalArgumentException {
-    Preconditions.checkArgument(
-        original != curr, "The current graph and the original graph refer to the same object");
+  public static DataGraph getGraphAtMutationNumber(DataGraph original, DataGraph curr, int mutationNum,
+      List<MultiMutation> multiMutList) throws IllegalArgumentException {
+    Preconditions.checkArgument(original != curr, "The current graph and the original graph refer to the same object");
 
     if (mutationNum < -1) {
       return null;
@@ -116,8 +114,7 @@ public final class Utility {
           }
         }
       }
-      return DataGraph.create(
-          curr.graph(), curr.graphNodesMap(), curr.roots(), mutationNum, curr.tokenMap());
+      return DataGraph.create(curr.graph(), curr.graphNodesMap(), curr.roots(), mutationNum, curr.tokenMap());
     } else {
       // Create a copy of the original graph and start from the original graph
       DataGraph originalCopy = original.getCopy();
@@ -131,23 +128,23 @@ public final class Utility {
           }
         }
       }
-      return DataGraph.create(
-          originalCopy.graph(),
-          originalCopy.graphNodesMap(),
-          originalCopy.roots(),
-          mutationNum,
+      return DataGraph.create(originalCopy.graph(), originalCopy.graphNodesMap(), originalCopy.roots(), mutationNum,
           original.tokenMap());
     }
   }
 
   /**
-   * Returns a multi-mutation (list of mutations) that need to be applied to get from the graph at
-   * currIndex to the graph at nextIndex as long as nextIndex = currIndex + 1
+   * Returns a multi-mutation (list of mutations) that need to be applied to get
+   * from the graph at currIndex to the graph at nextIndex as long as nextIndex =
+   * currIndex + 1
    *
-   * @param multiMutList the list of multi-mutations that are to be applied to the initial graph
-   * @param index the index in the above list at which the multimutation to apply is
-   * @return a multimutation with all the changes to apply to the current graph to get the next
-   *     graph or null if the provided indices are out of bounds or non-consecutive
+   * @param multiMutList the list of multi-mutations that are to be applied to the
+   *                     initial graph
+   * @param index        the index in the above list at which the multimutation to
+   *                     apply is
+   * @return a multimutation with all the changes to apply to the current graph to
+   *         get the next graph or null if the provided indices are out of bounds
+   *         or non-consecutive
    */
   public static MultiMutation getDiffBetween(List<MultiMutation> multiMutList, int index) {
     if (index < 0 || index >= multiMutList.size()) {
@@ -155,6 +152,7 @@ public final class Utility {
     }
     return multiMutList.get(index);
   }
+
   /**
    * Returns a list of the indices of the relevant
    *
@@ -162,8 +160,7 @@ public final class Utility {
    * @param origList the original list of mutations
    * @return a list of indices that are relevant to the node
    */
-  public static ArrayList<Integer> getMutationIndicesOfNode(
-      String nodeName, List<MultiMutation> origList) {
+  public static ArrayList<Integer> getMutationIndicesOfNode(String nodeName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
     // Shouldn't happen, but in case the nodeName is null an empty list is returned
     if (nodeName == null) {
@@ -185,10 +182,11 @@ public final class Utility {
   }
 
   /**
-   * Finds the INDEX of the element in searchList that is strictly GREATER than tgt in a SORTED list
+   * Finds the INDEX of the element in searchList that is strictly GREATER than
+   * tgt in a SORTED list
    *
    * @param searchList a list of integers to search through. Assumes it's sorted
-   * @param tgt the number to find the next biggest number from
+   * @param tgt        the number to find the next biggest number from
    * @return the INDEX of the next greater number. -1 if none
    */
   public static int getNextGreatestNumIndex(List<Integer> searchList, int tgt) {
@@ -208,13 +206,14 @@ public final class Utility {
         end = mid - 1;
       }
     }
-    if (ans == -1) return -1;
+    if (ans == -1)
+      return -1;
     return ans;
   }
 
   /**
-   * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
-   * contained in the graph
+   * Converts a Guava graph containing nodes of type GraphNode into a set of names
+   * of nodes contained in the graph
    *
    * @param graph the graph to return node names for
    * @return a set of names of nodes in the graph
@@ -223,15 +222,86 @@ public final class Utility {
     return graph.nodes().stream().map(node -> node.name()).collect(Collectors.toSet());
   }
 
+  public static List<Integer> mergeSortedLists(List<List<Integer>> sortedLists) {
+    int numLists = sortedLists.size();
+    if (sortedLists.size() == 0)
+      return null;
+    else if (sortedLists.size() == 1) {
+      return sortedLists.get(0);
+    } else {
+      int left = numLists / 2;
+      return mergeTwoLists(mergeSortedLists(new ArrayList<>(sortedLists.subList(0, left))),
+          mergeSortedLists(new ArrayList<>(sortedLists.subList(left, sortedLists.size()))));
+    }
+
+    // We merge two lists at a time until we get one list remaining
+    // while (numLists != 1) {
+    // int low = 0;
+    // int high = numLists - 1;
+    // while (low < high) {
+    // // System.out.println(mergeTwoLists(sortedLists.get(low),
+    // sortedLists.get(high)));
+    // System.out.println(sortedLists);
+    // sortedLists.set(low, mergeTwoLists(sortedLists.get(low),
+    // sortedLists.get(high)));
+    // low++;
+    // high--;
+    // }
+    // numLists = high + 1;
+    // }
+    // return sortedLists.get(0);
+  }
+
+  public static List<Integer> mergeTwoLists(List<Integer> l1, List<Integer> l2) {
+    System.out.println(l1);
+    System.out.println(l2);
+    ArrayList<Integer> result = new ArrayList<>();
+    int pointer1 = 0;
+    int pointer2 = 0;
+
+    while (pointer1 < l1.size() && pointer2 < l2.size()) {
+      int smallest;
+      if (l1.get(pointer1) <= l2.get(pointer2)) {
+        smallest = l1.get(pointer1);
+        pointer1++;
+      } else {
+        smallest = l2.get(pointer2);
+        pointer2++;
+      }
+      // no duplicates
+      if (result.size() == 0 || result.get(result.size() - 1) != smallest) {
+        result.add(smallest);
+      }
+    }
+    System.out.println(pointer1);
+    System.out.println(pointer2);
+    // Check individual, if the other has reached the bounds
+    while (pointer1 < l1.size()) {
+      System.out.println("hello");
+      if (result.size() == 0 || result.get(result.size() - 1) != l1.get(pointer1)) {
+        result.add(l1.get(pointer1));
+      }
+      pointer1++;
+    }
+    while (pointer2 < l2.size()) {
+      if (result.size() == 0 || result.get(result.size() - 1) != l2.get(pointer2)) {
+        result.add(l2.get(pointer2));
+      }
+      pointer2++;
+    }
+    System.out.println(result);
+    return result;
+  }
+
   /**
-   * Filters the mutations contained in this multimutation to be only the ones that affect the nodes
-   * in the provided set
+   * Filters the mutations contained in this multimutation to be only the ones
+   * that affect the nodes in the provided set
    *
-   * @param mm the multimutation to filter
+   * @param mm        the multimutation to filter
    * @param nodeNames the list of node names to return perninent mutations for
-   * @return a multimutation containing only those mutations in mm affecting nodes in nodeNames,
-   *     null if the multimutation is null and the multimutation itself if there is no name to
-   *     filter by
+   * @return a multimutation containing only those mutations in mm affecting nodes
+   *         in nodeNames, null if the multimutation is null and the multimutation
+   *         itself if there is no name to filter by
    */
   public static MultiMutation filterMultiMutationByNodes(MultiMutation mm, Set<String> nodeNames) {
     if (mm == null || nodeNames.size() == 0) {
@@ -246,9 +316,6 @@ public final class Utility {
         filteredMutationList.add(mut);
       }
     }
-    return MultiMutation.newBuilder()
-        .addAllMutation(filteredMutationList)
-        .setReason(mm.getReason())
-        .build();
+    return MultiMutation.newBuilder().addAllMutation(filteredMutationList).setReason(mm.getReason()).build();
   }
 }

--- a/src/main/java/com/google/sps/Utility.java
+++ b/src/main/java/com/google/sps/Utility.java
@@ -40,8 +40,8 @@ public final class Utility {
   }
 
   /**
-   * Converts a proto node object into a graph node object that does not store the names of the
-   * child nodes but may store additional information.
+   * Converts a proto node object into a graph node object that does not store the
+   * names of the child nodes but may store additional information.
    *
    * @param thisNode the input data Node object
    * @return a useful node used to construct the Guava Graph
@@ -54,50 +54,47 @@ public final class Utility {
   }
 
   /**
-   * Converts a Guava graph into a String encoding of a JSON Object. The object contains nodes and
-   * edges of the graph.
+   * Converts a Guava graph into a String encoding of a JSON Object. The object
+   * contains nodes and edges of the graph.
    *
-   * @param graph the graph to convert into a JSON String
+   * @param graph        the graph to convert into a JSON String
    * @param maxMutations the length of the list of mutations
-   * @param mutDiff the difference between the current graph and the requested graph
-   * @return a JSON object containing as entries the nodes and edges of this graph as well as the
-   *     length of the list of mutations this graph is an intermediate result of applying
+   * @param mutDiff      the difference between the current graph and the
+   *                     requested graph
+   * @return a JSON object containing as entries the nodes and edges of this graph
+   *         as well as the length of the list of mutations this graph is an
+   *         intermediate result of applying
    */
-  public static String graphToJson(
-      MutableGraph<GraphNode> graph, List<Integer> mutationIndices, MultiMutation mutDiff) {
-    Type typeOfNode = new TypeToken<Set<GraphNode>>() {}.getType();
-    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {}.getType();
-    Type typeOfIndices = new TypeToken<List<Integer>>() {}.getType();
+  public static String graphToJson(MutableGraph<GraphNode> graph, List<Integer> mutationIndices,
+      MultiMutation mutDiff) {
+    Type typeOfNode = new TypeToken<Set<GraphNode>>() {
+    }.getType();
+    Type typeOfEdge = new TypeToken<Set<EndpointPair<GraphNode>>>() {
+    }.getType();
+    Type typeOfIndices = new TypeToken<List<Integer>>() {
+    }.getType();
     Gson gson = new Gson();
     String nodeJson = gson.toJson(graph.nodes(), typeOfNode);
     String edgeJson = gson.toJson(graph.edges(), typeOfEdge);
-    String mutDiffJson =
-        (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
+    String mutDiffJson = (mutDiff == null || !mutDiff.isInitialized()) ? "" : gson.toJson(mutDiff.getMutationList());
     String reason = (mutDiff == null || !mutDiff.isInitialized()) ? "" : mutDiff.getReason();
     String mutationIndicesJson = gson.toJson(mutationIndices, typeOfIndices);
-    String resultJson =
-        new JSONObject()
-            .put("nodes", nodeJson)
-            .put("edges", edgeJson)
-            .put("mutationDiff", mutDiffJson)
-            .put("reason", reason)
-            .put("mutationIndices", mutationIndicesJson)
-            .toString();
+    String resultJson = new JSONObject().put("nodes", nodeJson).put("edges", edgeJson).put("mutationDiff", mutDiffJson)
+        .put("reason", reason).put("mutationIndices", mutationIndicesJson).toString();
     return resultJson;
   }
 
   /**
-   * @param original the original graph
-   * @param curr the current (most recently-requested) graph (requires that original != curr)
-   * @param mutationNum number of mutations to apply
+   * @param original     the original graph
+   * @param curr         the current (most recently-requested) graph (requires
+   *                     that original != curr)
+   * @param mutationNum  number of mutations to apply
    * @param multiMutList multi-mutation list
    * @return the resulting data graph or null if there was an error
    */
-  public static DataGraph getGraphAtMutationNumber(
-      DataGraph original, DataGraph curr, int mutationNum, List<MultiMutation> multiMutList)
-      throws IllegalArgumentException {
-    Preconditions.checkArgument(
-        original != curr, "The current graph and the original graph refer to the same object");
+  public static DataGraph getGraphAtMutationNumber(DataGraph original, DataGraph curr, int mutationNum,
+      List<MultiMutation> multiMutList) throws IllegalArgumentException {
+    Preconditions.checkArgument(original != curr, "The current graph and the original graph refer to the same object");
 
     if (mutationNum < -1) {
       return null;
@@ -117,8 +114,7 @@ public final class Utility {
           }
         }
       }
-      return DataGraph.create(
-          curr.graph(), curr.graphNodesMap(), curr.roots(), mutationNum, curr.tokenMap());
+      return DataGraph.create(curr.graph(), curr.graphNodesMap(), curr.roots(), mutationNum, curr.tokenMap());
     } else {
       // Create a copy of the original graph and start from the original graph
       DataGraph originalCopy = original.getCopy();
@@ -132,23 +128,23 @@ public final class Utility {
           }
         }
       }
-      return DataGraph.create(
-          originalCopy.graph(),
-          originalCopy.graphNodesMap(),
-          originalCopy.roots(),
-          mutationNum,
+      return DataGraph.create(originalCopy.graph(), originalCopy.graphNodesMap(), originalCopy.roots(), mutationNum,
           original.tokenMap());
     }
   }
 
   /**
-   * Returns a multi-mutation (list of mutations) that need to be applied to get from the graph at
-   * currIndex to the graph at nextIndex as long as nextIndex = currIndex + 1
+   * Returns a multi-mutation (list of mutations) that need to be applied to get
+   * from the graph at currIndex to the graph at nextIndex as long as nextIndex =
+   * currIndex + 1
    *
-   * @param multiMutList the list of multi-mutations that are to be applied to the initial graph
-   * @param index the index in the above list at which the multimutation to apply is
-   * @return a multimutation with all the changes to apply to the current graph to get the next
-   *     graph or null if the provided indices are out of bounds or non-consecutive
+   * @param multiMutList the list of multi-mutations that are to be applied to the
+   *                     initial graph
+   * @param index        the index in the above list at which the multimutation to
+   *                     apply is
+   * @return a multimutation with all the changes to apply to the current graph to
+   *         get the next graph or null if the provided indices are out of bounds
+   *         or non-consecutive
    */
   public static MultiMutation getMultiMutationAtIndex(List<MultiMutation> multiMutList, int index) {
     if (index < 0 || index >= multiMutList.size()) {
@@ -158,14 +154,14 @@ public final class Utility {
   }
 
   /**
-   * Returns a list of the indices of the mutations in origList that mutate nodeName
+   * Returns a list of the indices of the mutations in origList that mutate
+   * nodeName
    *
    * @param nodeName the name of the node to filter
    * @param origList the original list of mutations
    * @return a list of indices that are relevant to the node
    */
-  public static ArrayList<Integer> getMutationIndicesOfNode(
-      String nodeName, List<MultiMutation> origList) {
+  public static ArrayList<Integer> getMutationIndicesOfNode(String nodeName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
     // Shouldn't happen, but in case the nodeName is null an empty list is returned
     if (nodeName == null) {
@@ -187,14 +183,57 @@ public final class Utility {
   }
 
   /**
+   * Returns a list of the indices of the mutations in origList that mutate
+   * @param nodeName the name of the node to filter
+   * @param origList the original list of mutations
+   * @param tokenName paramter for token name. list ends when that token is
+   *                  deleted
+   * @return a list of indices that are relevant to the node, truncated at the point a given token is deleted
+   */
+  public static ArrayList<Integer> getMutationIndicesOfNode(String nodeName, List<MultiMutation> origList,
+      String tokenNameSearched) {
+    ArrayList<Integer> lst = new ArrayList<>();
+    // Shouldn't happen, but in case the nodeName is null an empty list is returned
+    if (nodeName == null) {
+      return lst;
+    }
+    for (int i = 0; i < origList.size(); i++) {
+      MultiMutation multiMut = origList.get(i);
+      List<Mutation> mutList = multiMut.getMutationList();
+      for (Mutation mut : mutList) {
+        String startName = mut.getStartNode();
+        String endName = mut.getEndNode();
+        if (nodeName.equals(startName) || nodeName.equals(endName)) {
+          lst.add(i);
+          // If the mutation is a delete token AND the token passed in as param is
+          // deleted, then we want no more
+          if (tokenNameSearched.length() != 0 && mut.getType().equals(Mutation.Type.CHANGE_TOKEN)) {
+            TokenMutation tokenMut = mut.getTokenChange();
+            TokenMutation.Type tokenMutType = tokenMut.getType();
+            if (tokenMutType == TokenMutation.Type.DELETE_TOKEN) {
+              List<String> tokenNames = tokenMut.getTokenNameList();
+              if (tokenNames.contains(tokenNameSearched)) {
+                return lst;
+              }
+            }
+          }
+          
+          break;
+        }
+      }
+    }
+    return lst;
+  }
+
+  /**
    * Returns a list of indices on the original list that related to a given node
    *
    * @param tokenName the token name to search for
-   * @param origList the original list of mutations
-   * @return a list of indices, empty if tokenName is null or if token is not changed
+   * @param origList  the original list of mutations
+   * @return a list of indices, empty if tokenName is null or if token is not
+   *         changed
    */
-  public static ArrayList<Integer> getMutationIndicesOfToken(
-      String tokenName, List<MultiMutation> origList) {
+  public static ArrayList<Integer> getMutationIndicesOfToken(String tokenName, List<MultiMutation> origList) {
     ArrayList<Integer> lst = new ArrayList<>();
     if (tokenName == null) {
       return lst;
@@ -217,8 +256,8 @@ public final class Utility {
   }
 
   /**
-   * Converts a Guava graph containing nodes of type GraphNode into a set of names of nodes
-   * contained in the graph
+   * Converts a Guava graph containing nodes of type GraphNode into a set of names
+   * of nodes contained in the graph
    *
    * @param graph the graph to return node names for
    * @return a set of names of nodes in the graph
@@ -229,13 +268,13 @@ public final class Utility {
 
   public static List<Integer> mergeSortedLists(List<List<Integer>> sortedLists) {
     int numLists = sortedLists.size();
-    if (sortedLists.size() == 0) return new ArrayList<>();
+    if (sortedLists.size() == 0)
+      return new ArrayList<>();
     else if (sortedLists.size() == 1) {
       return sortedLists.get(0);
     } else {
       int left = numLists / 2;
-      return mergeTwoLists(
-          mergeSortedLists(new ArrayList<>(sortedLists.subList(0, left))),
+      return mergeTwoLists(mergeSortedLists(new ArrayList<>(sortedLists.subList(0, left))),
           mergeSortedLists(new ArrayList<>(sortedLists.subList(left, sortedLists.size()))));
     }
 
@@ -293,14 +332,14 @@ public final class Utility {
   }
 
   /**
-   * Filters the mutations contained in this multimutation to be only the ones that affect the nodes
-   * in the provided set
+   * Filters the mutations contained in this multimutation to be only the ones
+   * that affect the nodes in the provided set
    *
-   * @param mm the multimutation to filter
+   * @param mm        the multimutation to filter
    * @param nodeNames the list of node names to return perninent mutations for
-   * @return a multimutation containing only those mutations in mm affecting nodes in nodeNames,
-   *     null if the multimutation is null and the multimutation itself if there is no name to
-   *     filter by
+   * @return a multimutation containing only those mutations in mm affecting nodes
+   *         in nodeNames, null if the multimutation is null and the multimutation
+   *         itself if there is no name to filter by
    */
   public static MultiMutation filterMultiMutationByNodes(MultiMutation mm, Set<String> nodeNames) {
     if (mm == null || nodeNames.size() == 0) {
@@ -315,9 +354,6 @@ public final class Utility {
         filteredMutationList.add(mut);
       }
     }
-    return MultiMutation.newBuilder()
-        .addAllMutation(filteredMutationList)
-        .setReason(mm.getReason())
-        .build();
+    return MultiMutation.newBuilder().addAllMutation(filteredMutationList).setReason(mm.getReason()).build();
   }
 }

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -97,5 +97,5 @@ mutation {
   type: DELETE_NODE
   start_node: "I"
 }
-reason: "Add node I"
+reason: "Delete node I"
 }

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -58,6 +58,18 @@ mutation {
     token_name: "e.js"
   }
 }
+mutation {
+  type: ADD_NODE
+  start_node: "I"
+}
+mutation {
+  type: CHANGE_TOKEN
+  start_node: "I"
+  token_change {
+    type: ADD_TOKEN
+    token_name: "d.js"
+  }
+}
 reason: "Changing tokens of node B"
 }
 mutation {
@@ -67,5 +79,22 @@ mutation {
   end_node: "C"
 }
 reason: "Removing edge AC"
-
+}
+mutation {
+mutation {
+  type: CHANGE_TOKEN
+  start_node: "B"
+  token_change {
+    type: DELETE_TOKEN
+    token_name: "d.js"
+  }
+}
+reason: "Changing tokens of node B"
+}
+mutation {
+mutation {
+  type: DELETE_NODE
+  start_node: "I"
+}
+reason: "Changing tokens of node B"
 }

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -97,5 +97,5 @@ mutation {
   type: DELETE_NODE
   start_node: "I"
 }
-reason: "Changing tokens of node B"
+reason: "Add node I"
 }

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -71,7 +71,7 @@ mutation {
     token_name: "f.js"
   }
 }
-reason: "Changing tokens of node B"
+reason: "Add d and f to node B"
 }
 mutation {
 mutation {

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -71,7 +71,7 @@ mutation {
     token_name: "f.js"
   }
 }
-reason: "Add d and f to node B"
+reason: "Add d and f to node I"
 }
 mutation {
 mutation {

--- a/src/main/webapp/WEB-INF/mutation.textproto
+++ b/src/main/webapp/WEB-INF/mutation.textproto
@@ -68,6 +68,7 @@ mutation {
   token_change {
     type: ADD_TOKEN
     token_name: "d.js"
+    token_name: "f.js"
   }
 }
 reason: "Changing tokens of node B"

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -26,12 +26,9 @@ import tippy, { sticky } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/dist/backdrop.css';
 import 'tippy.js/animations/shift-away.css';
-<<<<<<< HEAD
+
 import { colorScheme, opacityScheme, borderScheme } from './constants.js';
-=======
-import { colorScheme, opacityScheme } from './constants.js';
 import "./style.scss";
->>>>>>> highToggle
 
 export {
   initializeNumMutations, setMutationIndexList, setCurrMutationNum, setCurrMutationIndex,
@@ -150,7 +147,7 @@ async function generateGraph() {
   // Graph nodes and edges received from server
   const nodes = JSON.parse(jsonResponse.nodes);
   const edges = JSON.parse(jsonResponse.edges);
-  totalNum = jsonResponse.totalMutNumber;
+  // totalNum = jsonResponse.totalMutNumber;
   const queriedNodes = JSON.parse(jsonResponse.queriedNodes);
 
   // Set all logs to be black

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -160,6 +160,7 @@ async function generateGraph() {
   const reason = jsonResponse["reason"];
 
   mutationIndexList = JSON.parse(jsonResponse.mutationIndices);
+  console.log(mutationIndexList)
   numMutations = mutationIndexList.length;
   maxNumMutations = jsonResponse.totalMutNumber;
 
@@ -258,6 +259,7 @@ function getUrl() {
       selectedDepth = 20;
     }
   }
+  console.log("url num", currMutationNum)
   const url = `/data?depth=${selectedDepth}&mutationNum=${currMutationNum}&nodeName=${nodeName}&tokenName=${tokenName}`;
   return url;
 }
@@ -773,12 +775,14 @@ function navigateGraph(amount) {
     // In this case, currMutationNum is in mutationIndexList, so update the 
     // index by the given amount (either +1 or -1)
     currMutationIndex += amount;
+    console.log("index 1", currMutationIndex);
   } else {
     // In this case, currMutationNum is the average of two adjacent indices
     // in mutationIndex list, so pressing next should move the index to the 
     // higher index (the ceil of the average) and pressing prev should move
     // the index to the lower index (the floor of the average)
     if (amount === 1) {
+      console.log("index", currMutationIndex);
       currMutationIndex = Math.ceil(currMutationIndex);
     } else {
       currMutationIndex = Math.floor(currMutationIndex);
@@ -792,6 +796,9 @@ function navigateGraph(amount) {
   }
   setMutationSliderValue(currMutationIndex);
   currMutationNum = (currMutationIndex === -1) ? -1 : mutationIndexList[currMutationIndex];
+  console.log(mutationIndexList)
+  console.log("index again", currMutationIndex)
+  console.log("num", currMutationNum);
 }
 
 /**

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -160,7 +160,6 @@ async function generateGraph() {
   const reason = jsonResponse["reason"];
 
   mutationIndexList = JSON.parse(jsonResponse.mutationIndices);
-  console.log(mutationIndexList)
   numMutations = mutationIndexList.length;
   maxNumMutations = jsonResponse.totalMutNumber;
 
@@ -259,7 +258,6 @@ function getUrl() {
       selectedDepth = 20;
     }
   }
-  console.log("url num", currMutationNum)
   const url = `/data?depth=${selectedDepth}&mutationNum=${currMutationNum}&nodeName=${nodeName}&tokenName=${tokenName}`;
   return url;
 }
@@ -356,8 +354,8 @@ function getGraphDisplay(graphNodes, graphEdges, mutList, reason, queriedNodes) 
   // Color the queried nodes (it's fuchsia because I thought it was pretty, but definitely open to change! )
   if (queriedNodes) {
     queriedNodes.forEach(nodeName => {
-      cy.$(nodeName).style('background-color', colorScheme["filteredNodeColor"]);
-      cy.$(nodeName).style('border-width', borderScheme['queriedBorder']);
+      cy.$id(nodeName).style('background-color', colorScheme["filteredNodeColor"]);
+      cy.$id(nodeName).style('border-width', borderScheme['queriedBorder']);
     })
   }
 
@@ -775,14 +773,12 @@ function navigateGraph(amount) {
     // In this case, currMutationNum is in mutationIndexList, so update the 
     // index by the given amount (either +1 or -1)
     currMutationIndex += amount;
-    console.log("index 1", currMutationIndex);
   } else {
     // In this case, currMutationNum is the average of two adjacent indices
     // in mutationIndex list, so pressing next should move the index to the 
     // higher index (the ceil of the average) and pressing prev should move
     // the index to the lower index (the floor of the average)
     if (amount === 1) {
-      console.log("index", currMutationIndex);
       currMutationIndex = Math.ceil(currMutationIndex);
     } else {
       currMutationIndex = Math.floor(currMutationIndex);
@@ -796,9 +792,6 @@ function navigateGraph(amount) {
   }
   setMutationSliderValue(currMutationIndex);
   currMutationNum = (currMutationIndex === -1) ? -1 : mutationIndexList[currMutationIndex];
-  console.log(mutationIndexList)
-  console.log("index again", currMutationIndex)
-  console.log("num", currMutationNum);
 }
 
 /**

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -130,7 +130,7 @@ async function generateGraph() {
   // Graph nodes and edges received from server
   const nodes = JSON.parse(jsonResponse.nodes);
   const edges = JSON.parse(jsonResponse.edges);
-  // totalNum = jsonResponse.totalMutNumber;
+
   const queriedNodes = JSON.parse(jsonResponse.queriedNodes);
 
   // Set all logs to be black
@@ -145,7 +145,6 @@ async function generateGraph() {
   mutationIndexList = JSON.parse(jsonResponse.mutationIndices);
   numMutations = mutationIndexList.length;
   maxNumMutations = jsonResponse.totalMutNumber;
-  const queriedNodes = JSON.parse(jsonResponse.queriedNodes);
 
   if (!nodes || !edges || !Array.isArray(nodes) || !Array.isArray(edges)) {
     displayError("Malformed graph received from server - edges or nodes are empty");


### PR DESCRIPTION
Changes in this PR 
- Integrate next/prev buttons & timeline with filtering by token across multiple graphs
- Include function that gets the mutations for a token, and gets the mutations of a collection of nodes
- Add tests for new functionality
- Modify headers to be more clear
- Filter the diff by truncatedNodeNames and the nodes with the token

Filtering by JZBOxLeUAkj5cdKDoYRFbULqWRZYWgeqaqAHyIIslaLJE5dyQr4vMrp1u85SS8HcxMHDsyyCBg
[capture.zip](https://github.com/googleinterns/step49-2020/files/4989931/capture.zip)
![Screenshot 2020-07-28 at 12 06 39 PM](https://user-images.githubusercontent.com/48307028/88698072-312a0f80-d0cb-11ea-9f68-2aba81e635a2.png)
![Screenshot 2020-07-28 at 12 06 46 PM](https://user-images.githubusercontent.com/48307028/88698082-34250000-d0cb-11ea-94c2-1ad78687dc57.png)

